### PR TITLE
feat: ✅ autodetect first release, remove related option

### DIFF
--- a/packages/semver/jest.config.js
+++ b/packages/semver/jest.config.js
@@ -9,6 +9,6 @@ module.exports = {
   transform: {
     '^.+\\.[tj]sx?$': 'ts-jest',
   },
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
   coverageDirectory: '../../coverage/packages/semver',
 };

--- a/packages/semver/src/builders/version/builder.ts
+++ b/packages/semver/src/builders/version/builder.ts
@@ -1,11 +1,14 @@
-import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
+import {
+  BuilderContext,
+  BuilderOutput,
+  createBuilder,
+} from '@angular-devkit/architect';
 import { noop } from '@angular-devkit/schematics';
 import { existsSync } from 'fs';
 import { resolve } from 'path';
 import { from, Observable, of } from 'rxjs';
 import { catchError, map, mapTo, switchMap, switchMapTo } from 'rxjs/operators';
-import { release } from './release';
-
+import * as standardVersion from 'standard-version';
 import { VersionBuilderSchema } from './schema';
 import { getPackageFiles, getProjectRoot, tryPushToGitRemote } from './utils';
 
@@ -13,14 +16,7 @@ export function runBuilder(
   options: VersionBuilderSchema,
   context: BuilderContext
 ): Observable<BuilderOutput> {
-  const {
-    push,
-    remote,
-    dryRun,
-    baseBranch,
-    noVerify,
-    syncVersions,
-  } = options;
+  const { push, remote, dryRun, baseBranch, noVerify, syncVersions } = options;
 
   return from(getProjectRoot(context)).pipe(
     switchMap((projectRoot) =>
@@ -35,7 +31,7 @@ export function runBuilder(
       const changelogPath = resolve(projectRoot, 'CHANGELOG.md');
       const firstRelease = existsSync(changelogPath) === false;
 
-      return release({
+      return standardVersion({
         silent: false,
         path: projectRoot,
         dryRun,

--- a/packages/semver/src/builders/version/release.ts
+++ b/packages/semver/src/builders/version/release.ts
@@ -1,5 +1,0 @@
-import * as standardVersion from 'standard-version';
-
-export function release(config: standardVersion.Options): Promise<void> {
-  return standardVersion(config);
-}

--- a/packages/semver/src/builders/version/release.ts
+++ b/packages/semver/src/builders/version/release.ts
@@ -1,0 +1,5 @@
+import * as standardVersion from 'standard-version';
+
+export function release(config: standardVersion.Options): Promise<void> {
+  return standardVersion(config);
+}

--- a/packages/semver/src/builders/version/schema.d.ts
+++ b/packages/semver/src/builders/version/schema.d.ts
@@ -3,7 +3,6 @@ import { JsonObject } from '@angular-devkit/core';
 export interface VersionBuilderSchema extends JsonObject {
   dryRun?: boolean;
   noVerify?: boolean;
-  firstRelease?: boolean;
   push?: boolean;
   remote?: string;
   baseBranch?: string;

--- a/packages/semver/src/builders/version/schema.json
+++ b/packages/semver/src/builders/version/schema.json
@@ -15,11 +15,6 @@
       "type": "boolean",
       "default": false
     },
-    "firstRelease": {
-      "description": "Generate your CHANGELOG for your first release.",
-      "type": "boolean",
-      "default": false
-    },
     "push": {
       "description": "Pushes to the git remote.",
       "type": "boolean",


### PR DESCRIPTION
Close #1

I had some issues with the `standard-version` mock that was not restored after each tests, that's why I touched the jest.config and created a release.ts file. @yjaaidi if you know a sexier way to mock this here, let me know. I'm not a fan of `release.release` but I struggled a long time...