### PR TITLE
feat: ✅ bump version explicitly through parameters

### DIFF
--- a/packages/semver/src/builders/version/builder.e2e.spec.ts
+++ b/packages/semver/src/builders/version/builder.e2e.spec.ts
@@ -441,7 +441,197 @@ $`)
       );
     });
   });
+
+  describe('workspace with --version=major', () => {
+    beforeAll(async () => {
+      testingWorkspace = setupTestingWorkspace(new Map(commonWorkspaceFiles));
+
+      /* Commit changes. */
+      commitChanges();
+
+      /* Run builder. */
+      result = await runBuilder(
+        {
+          ...defaultBuilderOptions,
+          syncVersions: true,
+          version: 'major',
+        },
+        createFakeContext({
+          project: 'workspace',
+          projectRoot: testingWorkspace.root,
+          workspaceRoot: testingWorkspace.root,
+        })
+      ).toPromise();
+    });
+
+    afterAll(() => testingWorkspace.tearDown());
+
+    it('should return success', () => {
+      expect(result).toEqual({ success: true });
+    });
+
+    it('should commit all changes', () => {
+      expect(uncommitedChanges()).toHaveLength(0);
+    });
+
+    it('should bump root package.json', async () => {
+      expect((await readPackageJson('.').toPromise()).version).toEqual('1.0.0');
+    });
+
+    it(`should bump "a"'s package.json`, async () => {
+      expect((await readPackageJson('packages/a').toPromise()).version).toEqual(
+        '1.0.0'
+      );
+    });
+
+    it('should generate root changelog', async () => {
+      expect(readFileSync('CHANGELOG.md', 'utf-8')).toMatch(
+        new RegExp(`^# Changelog
+
+This file was generated.*
+
+# 1.0.0 \\(.*\\)
+
+
+### Bug Fixes
+
+\\* \\*\\*b:\\*\\* 🐞 fix emptiness .*
+
+
+### Features
+
+\\* \\*\\*a:\\*\\* 🚀 new feature .*
+$`)
+      );
+    });
+
+    it('should generate sub-changelogs', async () => {
+      expect(readFileSync('packages/a/CHANGELOG.md', 'utf-8')).toMatch(
+        new RegExp(`^# Changelog
+
+This file was generated.*
+
+# 1.0.0 \\(.*\\)
+
+
+### Features
+
+\\* \\*\\*a:\\*\\* 🚀 new feature .*
+$`)
+      );
+
+      expect(readFileSync('packages/b/CHANGELOG.md', 'utf-8')).toMatch(
+        new RegExp(`^# Changelog
+
+This file was generated.*
+
+# 1.0.0 \\(.*\\)
+
+
+### Bug Fixes
+
+\\* \\*\\*b:\\*\\* 🐞 fix emptiness .*
+$`)
+      );
+    });
+  });
+
+  describe('workspace with --version=prerelease --preid=beta', () => {
+    beforeAll(async () => {
+      testingWorkspace = setupTestingWorkspace(new Map(commonWorkspaceFiles));
+
+      /* Commit changes. */
+      commitChanges();
+
+      /* Run builder. */
+      result = await runBuilder(
+        {
+          ...defaultBuilderOptions,
+          syncVersions: true,
+          version: 'prerelease',
+          preid: 'beta',
+        },
+        createFakeContext({
+          project: 'workspace',
+          projectRoot: testingWorkspace.root,
+          workspaceRoot: testingWorkspace.root,
+        })
+      ).toPromise();
+    });
+
+    afterAll(() => testingWorkspace.tearDown());
+
+    it('should return success', () => {
+      expect(result).toEqual({ success: true });
+    });
+
+    it('should commit all changes', () => {
+      expect(uncommitedChanges()).toHaveLength(0);
+    });
+
+    it('should bump root package.json', async () => {
+      expect((await readPackageJson('.').toPromise()).version).toEqual('0.0.1-beta.0');
+    });
+
+    it(`should bump "a"'s package.json`, async () => {
+      expect((await readPackageJson('packages/a').toPromise()).version).toEqual(
+        '0.0.1-beta.0'
+      );
+    });
+
+    it('should generate root changelog', async () => {
+      expect(readFileSync('CHANGELOG.md', 'utf-8')).toMatch(
+        new RegExp(`^# Changelog
+
+This file was generated.*
+
+## 0.0.1-beta.0 \\(.*\\)
+
+
+### Bug Fixes
+
+\\* \\*\\*b:\\*\\* 🐞 fix emptiness .*
+
+
+### Features
+
+\\* \\*\\*a:\\*\\* 🚀 new feature .*
+$`)
+      );
+    });
+
+    it('should generate sub-changelogs', async () => {
+      expect(readFileSync('packages/a/CHANGELOG.md', 'utf-8')).toMatch(
+        new RegExp(`^# Changelog
+
+This file was generated.*
+
+## 0.0.1-beta.0 \\(.*\\)
+
+
+### Features
+
+\\* \\*\\*a:\\*\\* 🚀 new feature .*
+$`)
+      );
+
+      expect(readFileSync('packages/b/CHANGELOG.md', 'utf-8')).toMatch(
+        new RegExp(`^# Changelog
+
+This file was generated.*
+
+## 0.0.1-beta.0 \\(.*\\)
+
+
+### Bug Fixes
+
+\\* \\*\\*b:\\*\\* 🐞 fix emptiness .*
+$`)
+      );
+    });
+  });
 });
+
 
 function commitChanges() {
   execSync(

--- a/packages/semver/src/builders/version/builder.ts
+++ b/packages/semver/src/builders/version/builder.ts
@@ -19,6 +19,7 @@ export function runBuilder(
     syncVersions,
     rootChangelog,
     plugins,
+    version, preid,
   }: VersionBuilderSchema,
   context: BuilderContext
 ): Observable<BuilderOutput> {
@@ -30,7 +31,10 @@ export function runBuilder(
     shareReplay({ refCount: true, bufferSize: 1 })
   );
   const newVersion$ = projectRoot$.pipe(
-    switchMap((projectRoot) => tryBump({ preset, projectRoot, tagPrefix }))
+    switchMap((projectRoot) => tryBump({
+      preset, projectRoot, tagPrefix,
+      releaseType: version || null, preid: preid || null,
+    }))
   );
 
   const action$ = forkJoin([projectRoot$, newVersion$]).pipe(

--- a/packages/semver/src/builders/version/schema.d.ts
+++ b/packages/semver/src/builders/version/schema.d.ts
@@ -11,4 +11,6 @@ export interface VersionBuilderSchema extends JsonObject {
   syncVersions?: boolean;
   rootChangelog?: boolean;
   plugins?: PluginDef[];
+  version?: 'patch' | 'minor' | 'major' | 'premajor' | 'preminor' | 'prepatch' | 'prerelease';
+  preid?: string;
 }

--- a/packages/semver/src/builders/version/utils/try-bump.spec.ts
+++ b/packages/semver/src/builders/version/utils/try-bump.spec.ts
@@ -37,9 +37,47 @@ describe('tryBump', () => {
       preset: 'angular',
       projectRoot: '/libs/demo',
       tagPrefix: 'demo-',
+      releaseType: null, preid: null,
     }).toPromise();
 
     expect(newVersion).toEqual('2.2.0');
+
+    expect(mockGetCommits).toBeCalledTimes(1);
+    expect(mockGetCommits).toBeCalledWith({
+      projectRoot: '/libs/demo',
+      since: 'demo-2.1.0',
+    });
+
+    expect(mockConventionalRecommendedBump).toBeCalledTimes(1);
+    expect(mockConventionalRecommendedBump).toBeCalledWith(
+      {
+        path: '/libs/demo',
+        preset: 'angular',
+        tagPrefix: 'demo-',
+      },
+      expect.any(Function)
+    );
+  });
+
+  it('should use given type to calculate next version', async () => {
+    mockGetCommits.mockReturnValue(of(['feat: A', 'feat: B']));
+    /* Mock bump to return "minor". */
+    mockConventionalRecommendedBump.mockImplementation(
+      callbackify(
+        jest.fn().mockResolvedValue({
+          releaseType: 'minor',
+        })
+      )
+    );
+
+    const newVersion = await tryBump({
+      preset: 'angular',
+      projectRoot: '/libs/demo',
+      tagPrefix: 'demo-',
+      releaseType: 'premajor', preid: 'alpha',
+    }).toPromise();
+
+    expect(newVersion).toEqual('3.0.0-alpha.0');
 
     expect(mockGetCommits).toBeCalledTimes(1);
     expect(mockGetCommits).toBeCalledWith({
@@ -66,6 +104,7 @@ describe('tryBump', () => {
       preset: 'angular',
       projectRoot: '/libs/demo',
       tagPrefix: 'demo-',
+      releaseType: null, preid: null,
     }).toPromise();
 
     expect(mockGetCommits).toBeCalledTimes(1);
@@ -82,6 +121,7 @@ describe('tryBump', () => {
       preset: 'angular',
       projectRoot: '/libs/demo',
       tagPrefix: 'demo-',
+      releaseType: null, preid: null,
     }).toPromise();
     expect(newVersion).toBe(null);
 


### PR DESCRIPTION
* `major`, `minor` and `patch` are able to be specified through command line
* prerelease identifiers are supported within this explicit bumping that follows the original semver design: https://github.com/npm/node-semver#prerelease-identifiers

This pull request closes #56