### PR TITLE
Run 'git add' at once after all changelog files have been generated

### DIFF
--- a/packages/semver/src/builders/version/utils/changelog.ts
+++ b/packages/semver/src/builders/version/utils/changelog.ts
@@ -38,8 +38,6 @@ export function updateChangelog({
       },
       newVersion
     );
-    if (!dryRun) {
-      await promisify(execFile)('git', ['add', changelogPath]);
-    }
+    return changelogPath;
   });
 }

--- a/packages/semver/src/builders/version/utils/changelog.ts
+++ b/packages/semver/src/builders/version/utils/changelog.ts
@@ -1,7 +1,5 @@
-import { execFile } from 'child_process';
 import { resolve } from 'path';
 import { defer } from 'rxjs';
-import { promisify } from 'util';
 import * as changelog from 'standard-version/lib/lifecycles/changelog';
 import * as standardVersionDefaults from 'standard-version/defaults';
 

--- a/packages/semver/src/builders/version/utils/git.ts
+++ b/packages/semver/src/builders/version/utils/git.ts
@@ -79,3 +79,8 @@ export function tryPushToGitRemote({
     );
   });
 }
+
+export function gitAdd(paths: string[], dryRun = false): Observable<{ stderr: string, stdout: string}> {
+  console.log(paths);
+  return defer(() => execAsync('git', ['add', ...paths]));
+}

--- a/packages/semver/src/builders/version/utils/git.ts
+++ b/packages/semver/src/builders/version/utils/git.ts
@@ -80,7 +80,12 @@ export function tryPushToGitRemote({
   });
 }
 
-export function gitAdd(paths: string[], dryRun = false): Observable<{ stderr: string, stdout: string}> {
-  console.log(paths);
-  return defer(() => execAsync('git', ['add', ...paths]));
+export function gitAdd(
+  paths: string[],
+  dryRun = false
+): Observable<{ stderr: string; stdout: string }> {
+  return defer(() => {
+    const gitAddOptions = [...(dryRun ? ['--dry-run'] : []), ...paths];
+    return execAsync('git', ['add', ...gitAddOptions]);
+  });
 }

--- a/packages/semver/src/builders/version/version.ts
+++ b/packages/semver/src/builders/version/version.ts
@@ -7,6 +7,7 @@ import {
   getChangelogPath,
   updateChangelog,
 } from './utils/changelog';
+import { gitAdd } from './utils/git';
 import { getPackageFiles, getProjectRoots } from './utils/workspace';
 
 export interface CommonVersionOptions {
@@ -44,7 +45,8 @@ export function versionWorkspace({
                 })
               )
           )
-        )
+        ),
+        switchMap((changelogPaths) => gitAdd(changelogPaths))
       ),
       getPackageFiles(workspaceRoot).pipe(
         switchMap((packageFiles) =>


### PR DESCRIPTION
This PR addresses https://github.com/jscutlery/semver/issues/95 which is caused by trying to stage the changelog files concurrently. The solution is generating/updating all the changelog files then stage them all at once.