### PR TITLE
Skip individual changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,17 +89,18 @@ nx run workspace:version --version=prerelease --preid=beta
 
 #### Available options:
 
-| name                   | type      | default    | description                                    |
-| ---------------------- | --------- | ---------- | ---------------------------------------------- |
-| **`--dry-run`**        | `boolean` | `false`    | run with dry mode                              |
-| **`--no-verify`**      | `boolean` | `false`    | skip git hooks                                 |
-| **`--push`**           | `boolean` | `false`    | push the release                               |
-| **`--sync-versions`**  | `boolean` | `false`    | lock/sync versions between projects            |
-| **`--root-changelog`** | `boolean` | `true`     | generate root CHANGELOG containing all changes |
-| **`--origin`**         | `string`  | `'origin'` | push against git remote repository             |
-| **`--base-branch`**    | `string`  | `'main'`   | push against git base branch                   |
-| **`--version`**    | `string`  | `null`   | The level of change                   |
-| **`--preid`**    | `string`  | `null`   | Prerelease identifier               |
+| name                           | type      | default    | description                                                                 |
+| ------------------------------ | --------- | ---------- | --------------------------------------------------------------------------- |
+| **`--dry-run`**                | `boolean` | `false`    | run with dry mode                                                           |
+| **`--no-verify`**              | `boolean` | `false`    | skip git hooks                                                              |
+| **`--push`**                   | `boolean` | `false`    | push the release                                                            |
+| **`--sync-versions`**          | `boolean` | `false`    | lock/sync versions between projects                                         |
+| **`--skip-root-changelog`**    | `boolean` | `false`    | skip generating root CHANGELOG containing all changes (only with sync mode) |
+| **`--skip-project-changelog`** | `boolean` | `false`    | skip generating project CHANGELOG (only with sync mode)                     |
+| **`--origin`**                 | `string`  | `'origin'` | push against git remote repository                                          |
+| **`--base-branch`**            | `string`  | `'main'`   | push against git base branch                                                |
+| **`--version`**                | `string`  | `null`     | specify the level of change                                                 |
+| **`--preid`**                  | `string`  | `null`     | prerelease identifier                                                       |
 
 ## Changelog
 

--- a/packages/semver/migrations.json
+++ b/packages/semver/migrations.json
@@ -1,0 +1,9 @@
+{
+  "schematics": {
+    "migration-2-0-0": {
+      "version": "2.0.0",
+      "description": "Update @jscutlery/semver to version 2.0.0",
+      "factory": "./src/migrations/update-2-0-0"
+    }
+  }
+}

--- a/packages/semver/package.json
+++ b/packages/semver/package.json
@@ -13,6 +13,10 @@
   "ng-add": {
     "save": "devDependencies"
   },
+  "ng-update": {
+    "requirements": {},
+    "migrations": "./migrations.json"
+  },
   "dependencies": {
     "@angular-devkit/build-angular": "0.1102.7",
     "inquirer": "^7.3.3",

--- a/packages/semver/src/builders/version/builder.e2e.spec.ts
+++ b/packages/semver/src/builders/version/builder.e2e.spec.ts
@@ -16,7 +16,7 @@ describe('@jscutlery/semver:version', () => {
     push: false,
     remote: 'origin',
     baseBranch: 'main',
-    rootChangelog: true,
+    skipRootChangelog: false,
     syncVersions: false,
     plugins: [],
   };
@@ -376,7 +376,7 @@ $`)
       result = await runBuilder(
         {
           ...defaultBuilderOptions,
-          rootChangelog: false,
+          skipRootChangelog: true,
           syncVersions: true,
         },
         createFakeContext({

--- a/packages/semver/src/builders/version/builder.spec.ts
+++ b/packages/semver/src/builders/version/builder.spec.ts
@@ -79,7 +79,7 @@ describe('@jscutlery/semver:version', () => {
     remote: 'origin',
     baseBranch: 'main',
     syncVersions: false,
-    rootChangelog: true,
+    skipRootChangelog: false,
     plugins: [],
   };
 
@@ -231,13 +231,13 @@ describe('@jscutlery/semver:version', () => {
       );
     });
 
-    it('should generate root CHANGELOG only when requested', async () => {
+    it('should skip root CHANGELOG generation (--skip-root-changelog=true)', async () => {
       await runBuilder(
         {
           ...options,
           syncVersions: true,
           /* Disable root CHANGELOG */
-          rootChangelog: false,
+          skipRootChangelog: true,
         },
         context
       ).toPromise();

--- a/packages/semver/src/builders/version/builder.spec.ts
+++ b/packages/semver/src/builders/version/builder.spec.ts
@@ -80,6 +80,7 @@ describe('@jscutlery/semver:version', () => {
     baseBranch: 'main',
     syncVersions: false,
     skipRootChangelog: false,
+    skipProjectChangelog: false,
     plugins: [],
   };
 
@@ -248,6 +249,23 @@ describe('@jscutlery/semver:version', () => {
             changelog: true,
           },
         })
+      );
+    });
+
+    it('should skip project CHANGELOG generation (--skip-project-changelog=true)', async () => {
+      await runBuilder(
+        {
+          ...options,
+          syncVersions: true,
+          /* Disable project CHANGELOG */
+          skipProjectChangelog: true,
+        },
+        context
+      ).toPromise();
+
+      expect(mockChangelog).not.toBeCalled();
+      expect(mockAddToStage).toBeCalledWith(
+        expect.objectContaining({ paths: [] })
       );
     });
 

--- a/packages/semver/src/builders/version/builder.ts
+++ b/packages/semver/src/builders/version/builder.ts
@@ -18,6 +18,7 @@ export function runBuilder(
     noVerify,
     syncVersions,
     skipRootChangelog,
+    skipProjectChangelog,
     plugins,
     version,
     preid,
@@ -69,6 +70,7 @@ export function runBuilder(
           ? versionWorkspace({
               ...options,
               skipRootChangelog,
+              skipProjectChangelog,
               workspaceRoot,
             })
           : versionProject(options)

--- a/packages/semver/src/builders/version/builder.ts
+++ b/packages/semver/src/builders/version/builder.ts
@@ -17,7 +17,7 @@ export function runBuilder(
     baseBranch,
     noVerify,
     syncVersions,
-    rootChangelog,
+    skipRootChangelog,
     plugins,
     version,
     preid,
@@ -68,7 +68,7 @@ export function runBuilder(
         syncVersions
           ? versionWorkspace({
               ...options,
-              rootChangelog,
+              skipRootChangelog,
               workspaceRoot,
             })
           : versionProject(options)

--- a/packages/semver/src/builders/version/schema.d.ts
+++ b/packages/semver/src/builders/version/schema.d.ts
@@ -10,6 +10,7 @@ export interface VersionBuilderSchema extends JsonObject {
   baseBranch?: string;
   syncVersions?: boolean;
   skipRootChangelog?: boolean;
+  skipProjectChangelog?: boolean;
   plugins?: PluginDef[];
   version?: 'patch' | 'minor' | 'major' | 'premajor' | 'preminor' | 'prepatch' | 'prerelease';
   preid?: string;

--- a/packages/semver/src/builders/version/schema.d.ts
+++ b/packages/semver/src/builders/version/schema.d.ts
@@ -9,7 +9,7 @@ export interface VersionBuilderSchema extends JsonObject {
   remote?: string;
   baseBranch?: string;
   syncVersions?: boolean;
-  rootChangelog?: boolean;
+  skipRootChangelog?: boolean;
   plugins?: PluginDef[];
   version?: 'patch' | 'minor' | 'major' | 'premajor' | 'preminor' | 'prepatch' | 'prerelease';
   preid?: string;

--- a/packages/semver/src/builders/version/schema.json
+++ b/packages/semver/src/builders/version/schema.json
@@ -35,10 +35,10 @@
       "type": "boolean",
       "default": false
     },
-    "rootChangelog": {
-      "description": "Generate root CHANGELOG file containing all monorepo changes.",
+    "skipRootChangelog": {
+      "description": "Skip root CHANGELOG generation containing all monorepo changes (only with sync mode).",
       "type": "boolean",
-      "default": true
+      "default": false
     },
     "plugins": {
       "description": "Configurable plugins to extend release capabilities.",

--- a/packages/semver/src/builders/version/schema.json
+++ b/packages/semver/src/builders/version/schema.json
@@ -40,6 +40,11 @@
       "type": "boolean",
       "default": false
     },
+    "skipProjectChangelog": {
+      "description": "Skip project CHANGELOG generation (only with sync mode).",
+      "type": "boolean",
+      "default": false
+    },
     "plugins": {
       "description": "Configurable plugins to extend release capabilities.",
       "type": "array",

--- a/packages/semver/src/builders/version/utils/git.spec.ts
+++ b/packages/semver/src/builders/version/utils/git.spec.ts
@@ -157,7 +157,7 @@ describe('git', () => {
   });
 
   describe('addToStage', () => {
-    it('add to git stage', async () => {
+    it('should add to git stage', async () => {
       jest
         .spyOn(cp, 'execAsync')
         .mockReturnValue(of({ stderr: '', stdout: 'ok' }));
@@ -171,6 +171,19 @@ describe('git', () => {
         'git',
         expect.arrayContaining(['add', 'packages/demo/file.txt', 'packages/demo/other-file.ts'])
       );
+    });
+
+    it('should skip git add if paths argument is empty', async () => {
+      jest
+        .spyOn(cp, 'execAsync')
+        .mockReturnValue(of({ stderr: '', stdout: 'ok' }));
+
+      await addToStage({
+        paths: [],
+        dryRun: false,
+      }).toPromise();
+
+      expect(cp.execAsync).not.toBeCalled();
     });
   });
 

--- a/packages/semver/src/builders/version/utils/git.ts
+++ b/packages/semver/src/builders/version/utils/git.ts
@@ -1,5 +1,5 @@
 import * as gitRawCommits from 'git-raw-commits';
-import { defer, Observable, of, throwError } from 'rxjs';
+import { defer, Observable, of, throwError, EMPTY } from 'rxjs';
 import { catchError, last, scan, startWith, switchMap } from 'rxjs/operators';
 
 import { execAsync } from './exec-async';
@@ -87,10 +87,12 @@ export function addToStage({
   paths: string[];
   dryRun: boolean;
 }): Observable<{ stderr: string; stdout: string }> {
-  return defer(() => {
-    const gitAddOptions = [...(dryRun ? ['--dry-run'] : []), ...paths];
-    return execAsync('git', ['add', ...gitAddOptions]);
-  });
+  if (paths.length === 0) {
+    return EMPTY;
+  }
+
+  const gitAddOptions = [...(dryRun ? ['--dry-run'] : []), ...paths];
+  return execAsync('git', ['add', ...gitAddOptions]);
 }
 
 export function getFirstCommitRef(): Observable<string> {

--- a/packages/semver/src/builders/version/version.ts
+++ b/packages/semver/src/builders/version/version.ts
@@ -2,11 +2,8 @@ import { resolve } from 'path';
 import { concat, forkJoin } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import * as standardVersion from 'standard-version';
-import {
-  defaultHeader,
-  getChangelogPath,
-  updateChangelog,
-} from './utils/changelog';
+
+import { defaultHeader, getChangelogPath, updateChangelog } from './utils/changelog';
 import { addToStage } from './utils/git';
 import { getPackageFiles, getProjectRoots } from './utils/workspace';
 
@@ -20,11 +17,11 @@ export interface CommonVersionOptions {
 }
 
 export function versionWorkspace({
-  rootChangelog,
+  skipRootChangelog,
   workspaceRoot,
   ...options
 }: {
-  rootChangelog: boolean;
+  skipRootChangelog: boolean;
   workspaceRoot: string;
 } & CommonVersionOptions) {
   return concat(
@@ -55,7 +52,7 @@ export function versionWorkspace({
         switchMap((packageFiles) =>
           _runStandardVersion({
             bumpFiles: packageFiles,
-            skipChangelog: !rootChangelog,
+            skipChangelog: skipRootChangelog,
             ...options,
           })
         )

--- a/packages/semver/src/migrations/update-2-0-0/index.spec.ts
+++ b/packages/semver/src/migrations/update-2-0-0/index.spec.ts
@@ -1,0 +1,97 @@
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import { readWorkspace } from '@nrwl/workspace';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import * as path from 'path';
+
+const collectionPath = path.join(__dirname, '../../../migrations.json');
+
+function serializeJson(json: any) {
+  return `${JSON.stringify(json, null, 2)}\n`;
+}
+
+describe('2.0.0 migration schematic', () => {
+  let appTree: Tree;
+  let schematicRunner: SchematicTestRunner;
+
+  beforeEach(async () => {
+    schematicRunner = new SchematicTestRunner(
+      '@jscutlery/semver',
+      collectionPath
+    );
+
+    appTree = createEmptyWorkspace(Tree.empty());
+  });
+
+  it('should update --root-changelog=false option to --skip-root-changelog=true', async () => {
+    appTree.overwrite(
+      'workspace.json',
+      serializeJson({
+        version: 1,
+        projects: {
+          demo: {
+            architect: {
+              version: {
+                builder: '@jscutlery/semver',
+                options: {
+                  rootChangelog: false,
+                },
+              },
+            },
+          },
+        },
+      })
+    );
+
+    const tree = await schematicRunner
+      .runSchematicAsync('migration-2-0-0', undefined, appTree)
+      .toPromise();
+
+    const workspace = readWorkspace(tree);
+
+    expect(workspace.projects.demo.architect.version.options).not.toContainKey(
+      'rootChangelog'
+    );
+    expect(workspace.projects.demo.architect.version.options).toEqual(
+      expect.objectContaining({
+        skipRootChangelog: true,
+      })
+    );
+  });
+
+  it('should update --root-changelog=true option to --skip-root-changelog=false', async () => {
+    appTree.overwrite(
+      'workspace.json',
+      serializeJson({
+        version: 1,
+        projects: {
+          demo: {
+            architect: {
+              version: {
+                builder: '@jscutlery/semver',
+                options: {
+                  rootChangelog: true,
+                },
+              },
+            },
+          },
+        },
+      })
+    );
+
+    const tree = await schematicRunner
+      .runSchematicAsync('migration-2-0-0', undefined, appTree)
+      .toPromise();
+
+    const workspace = readWorkspace(tree);
+
+    expect(workspace.projects.demo.architect.version.options).not.toContainKey(
+      'rootChangelog'
+    );
+    expect(workspace.projects.demo.architect.version.options).toEqual(
+      expect.objectContaining({
+        skipRootChangelog: false,
+      })
+    );
+  });
+});

--- a/packages/semver/src/migrations/update-2-0-0/index.ts
+++ b/packages/semver/src/migrations/update-2-0-0/index.ts
@@ -1,0 +1,30 @@
+import { Rule } from '@angular-devkit/schematics';
+import { updateWorkspace } from '@nrwl/workspace';
+
+export default function (): Rule {
+  return () => {
+    return updateWorkspace((workspace) => {
+      workspace.projects.forEach((project) => {
+        if (project.targets.has('version')) {
+          const options = project.targets.get('version').options ?? {};
+
+          /* Check if the outdated option is defined. */
+          if (typeof options.rootChangelog === 'boolean') {
+            const newOptions = {
+              skipRootChangelog: !options.rootChangelog,
+            };
+
+            /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+            const { rootChangelog, ...otherOptions } = options;
+            /* For a mysterious reason, to override the builder definition we have to delete it before. */
+            project.targets.delete('version');
+            project.targets.set('version', {
+              builder: '@jscutlery/semver',
+              options: { ...otherOptions, ...newOptions },
+            });
+          }
+        }
+      });
+    });
+  };
+}


### PR DESCRIPTION
Related to [this comment](https://github.com/jscutlery/semver/issues/135#issuecomment-815941240), add the ability to skip project changelog generation with sync mode. Also renamed --root-changelog option to --skip-root-changelog, which is more conventional.

We can also provide a migration script to automatically migrate to the new option. 