### PR TITLE
Allow to customize tag prefix (`--version-tag-prefix` option)

### DIFF
--- a/packages/semver/src/executors/version/index.spec.ts
+++ b/packages/semver/src/executors/version/index.spec.ts
@@ -112,6 +112,19 @@ describe('@jscutlery/semver:version', () => {
       );
     });
 
+    it('should run standard-version with a custom tag', async () => {
+      const { success } = await version({...options, versionTagPrefix: 'custom-tag-prefix/a-' }, context);
+
+      expect(success).toBe(true);
+      expect(standardVersion).toBeCalledWith(
+        expect.objectContaining({
+          header: expect.any(String),
+          dryRun: false,
+          tagPrefix: "custom-tag-prefix/a-",
+        })
+      );
+    });
+
     it('should not version if no commits since last release', async () => {
       mockTryBump.mockReturnValue(of(null));
 

--- a/packages/semver/src/executors/version/index.spec.ts
+++ b/packages/semver/src/executors/version/index.spec.ts
@@ -113,7 +113,7 @@ describe('@jscutlery/semver:version', () => {
     });
 
     it('should run standard-version with a custom tag', async () => {
-      const { success } = await version({...options, versionTagPrefix: 'custom-tag-prefix/a-' }, context);
+      const { success } = await version({...options, versionTagPrefix: 'custom-tag-prefix/${target}-' }, context);
 
       expect(success).toBe(true);
       expect(standardVersion).toBeCalledWith(

--- a/packages/semver/src/executors/version/index.ts
+++ b/packages/semver/src/executors/version/index.ts
@@ -6,6 +6,7 @@ import { VersionBuilderSchema } from './schema';
 import { tryPushToGitRemote } from './utils/git';
 import { tryBump } from './utils/try-bump';
 import { getProjectRoot } from './utils/workspace';
+import { resolveTagTemplate } from './utils/tag-template';
 import { CommonVersionOptions, versionProject, versionWorkspace } from './version';
 
 export default function version(
@@ -27,7 +28,8 @@ export default function version(
 ): Promise<{ success: boolean }> {
   const workspaceRoot = context.root;
   const preset = 'angular';
-  const tagPrefix = versionTagPrefix ? versionTagPrefix
+  const tagPrefix = versionTagPrefix ? resolveTagTemplate(versionTagPrefix,
+      { target: context.projectName, projectName: context.projectName })
     : (syncVersions ? 'v' : `${context.projectName}-`);
 
   const projectRoot = getProjectRoot(context);

--- a/packages/semver/src/executors/version/index.ts
+++ b/packages/semver/src/executors/version/index.ts
@@ -21,12 +21,14 @@ export default function version(
     version,
     preid,
     changelogHeader,
+    versionTagPrefix,
   }: VersionBuilderSchema,
   context: ExecutorContext
 ): Promise<{ success: boolean }> {
   const workspaceRoot = context.root;
   const preset = 'angular';
-  const tagPrefix = syncVersions ? 'v' : `${context.projectName}-`;
+  const tagPrefix = versionTagPrefix ? versionTagPrefix
+    : (syncVersions ? 'v' : `${context.projectName}-`);
 
   const projectRoot = getProjectRoot(context);
   const newVersion$ = tryBump({

--- a/packages/semver/src/executors/version/schema.d.ts
+++ b/packages/semver/src/executors/version/schema.d.ts
@@ -10,4 +10,5 @@ export interface VersionBuilderSchema {
   version?: 'patch' | 'minor' | 'major' | 'premajor' | 'preminor' | 'prepatch' | 'prerelease';
   preid?: string;
   changelogHeader?: string;
+  versionTagPrefix?: string;
 }

--- a/packages/semver/src/executors/version/schema.json
+++ b/packages/semver/src/executors/version/schema.json
@@ -56,6 +56,10 @@
     "preid": {
       "description": "Use the next semantic prerelease version with a specific prerelease identifier.",
       "type": "string"
+    },
+    "versionTagPrefix": {
+      "description": "Version tag prefix. Defaults are 'v' and '${target}-' for sync and async modes.",
+      "type": "string"
     }
   },
   "required": []

--- a/packages/semver/src/executors/version/schema.json
+++ b/packages/semver/src/executors/version/schema.json
@@ -58,7 +58,7 @@
       "type": "string"
     },
     "versionTagPrefix": {
-      "description": "Version tag prefix. Defaults are 'v' and '${target}-' for sync and async modes.",
+      "description": "Version tag prefix. Defaults are 'v' and '${target}-' for sync and independent modes. ${target} will be replaced with context target value for independent mode.",
       "type": "string"
     }
   },

--- a/packages/semver/src/executors/version/utils/tag-template.spec.ts
+++ b/packages/semver/src/executors/version/utils/tag-template.spec.ts
@@ -1,0 +1,20 @@
+import { resolveTagTemplate } from './tag-template';
+
+describe('resolveTagTemplate', () => {
+  const testContext = { test1: 'xxx', test2: 'yyy' };
+
+  it('should do noting to the template string', () => {
+    expect(resolveTagTemplate('test string that have test1 and ${nothing} in it', testContext))
+      .toBe('test string that have test1 and ${nothing} in it');
+  });
+
+  it('should replace all ${test1} placeholders', () => {
+    expect(resolveTagTemplate('test string with ${test1}, when ${test1} repeat itself', testContext))
+      .toBe('test string with xxx, when xxx repeat itself');
+  });
+
+  it('should replace all ${test1} and ${test2} placeholders', () => {
+    expect(resolveTagTemplate('test string with ${test1} and ${test2}', testContext))
+      .toBe('test string with xxx and yyy');
+  });
+});

--- a/packages/semver/src/executors/version/utils/tag-template.ts
+++ b/packages/semver/src/executors/version/utils/tag-template.ts
@@ -1,0 +1,10 @@
+export interface TagTemplateContext {
+  [key: string]: string;
+}
+
+export function resolveTagTemplate(template: string, resolvingContext: TagTemplateContext): string {
+  return Object.keys(resolvingContext)
+    .reduce((accumulator, contextParamKey) => accumulator
+      .replace(new RegExp(`\\$\\{${contextParamKey}}`, 'g'),
+        resolvingContext[contextParamKey]), template);
+}


### PR DESCRIPTION
It's will be very useful feature for my current workplace project. Our CI/CD almost fully automated but our current script for version calculation is a kinda buggy, so I decided to switch it over this nx semver plugin (in this moment we are in the middle of refactoring our applications into nx mono repository) and actually this plugin is exactly what we need but it's missing critical for us feature - custom tag prefix. Our current pipelines are using additional information from tag for building process,  for example: we have 4 stages like development, qa, predproduction and production, and each of them can have different features and fixes sets that depends on what exactly was tested on previous stage, so when we building application it's going to be built with tags like `release/development/v1.71.188` or `release/qa/v1.69.50` to make sure that it will be deployed on right stage after mirroring into devops repository.