### PR TITLE
Adding `--use-deps` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,9 @@ nx run workspace:version --version=prerelease --preid=beta
 | **`--origin`**                 | `string`  | `'origin'` | push against git remote repository                                                                                                                |
 | **`--base-branch`**            | `string`  | `'main'`   | push against git base branch                                                                                                                      |
 | **`--version`**                | `string`  | `null`     | specify the level of change                                                                                                                       |
-| **`--preid`**                  | `string`  | `null`     | prerelease identifier                                                                                                                             |
-| **`--version-tag-prefix`**     | `string`  | `null`     | Version tag prefix, defaults are `'v'` and `'${target}-'` for sync and independent modes, `${target}` will be replaced with context target value. |
+| **`--preid`**                  | `string`  | `null`     | prerelease identifier                                                                                                                              |
+| **`--version-tag-prefix`**      | `string`  | `null`     | Version tag prefix, defaults are `'v'` and `'${target}-'` for sync and independent modes, `${target}` will be replaced with context target value.  |
+| **`--use-deps`**               | `boolean` | `false`    | Flag to use dependencies as part of calculating a version bump.                                                                                   |
 
 ## Changelog
 

--- a/packages/semver/src/executors/version/index.e2e.spec.ts
+++ b/packages/semver/src/executors/version/index.e2e.spec.ts
@@ -14,6 +14,7 @@ describe('@jscutlery/semver:version', () => {
   const defaultBuilderOptions: VersionBuilderSchema = {
     dryRun: false,
     noVerify: false,
+    useDeps: false,
     push: false,
     remote: 'origin',
     baseBranch: 'main',

--- a/packages/semver/src/executors/version/index.ts
+++ b/packages/semver/src/executors/version/index.ts
@@ -10,12 +10,14 @@ import { versionProject, versionWorkspace } from './version';
 
 import type { CommonVersionOptions } from './version';
 import type { VersionBuilderSchema } from './schema';
+import { getProjectDependencies } from './utils/get-project-dependencies';
 
-export default function version(
+export default async function version(
   {
     push,
     remote,
     dryRun,
+    useDeps,
     baseBranch,
     noVerify,
     syncVersions,
@@ -35,9 +37,24 @@ export default function version(
     : (syncVersions ? 'v' : `${context.projectName}-`);
 
   const projectRoot = getProjectRoot(context);
+
+  let dependencyRoots = [];
+  if (useDeps && !version) {
+    // Include any depended-upon libraries in determining the version bump.
+    try {
+      const dependencyLibs = await getProjectDependencies(context.projectName);
+      dependencyRoots = dependencyLibs
+        .map(name => context.workspace.projects[name].root);
+    } catch (e) {
+      logger.error('Failed to determine dependencies.');
+      return Promise.resolve(e);
+    }
+  }
+
   const newVersion$ = tryBump({
     preset,
     projectRoot,
+    dependencyRoots,
     tagPrefix,
     releaseType: version,
     preid,
@@ -52,6 +69,7 @@ export default function version(
 
       const options: CommonVersionOptions = {
         dryRun,
+        useDeps,
         newVersion,
         noVerify,
         preset,

--- a/packages/semver/src/executors/version/schema.d.ts
+++ b/packages/semver/src/executors/version/schema.d.ts
@@ -7,6 +7,7 @@ export interface VersionBuilderSchema {
   syncVersions?: boolean;
   skipRootChangelog?: boolean;
   skipProjectChangelog?: boolean;
+  useDeps?: boolean;
   version?: 'patch' | 'minor' | 'major' | 'premajor' | 'preminor' | 'prepatch' | 'prerelease';
   preid?: string;
   changelogHeader?: string;

--- a/packages/semver/src/executors/version/schema.json
+++ b/packages/semver/src/executors/version/schema.json
@@ -61,6 +61,11 @@
     "versionTagPrefix": {
       "description": "Version tag prefix. Defaults are 'v' and '${target}-' for sync and independent modes. ${target} will be replaced with context target value for independent mode.",
       "type": "string"
+    },
+    "useDeps": {
+      "description": "Include's the project's dependencies in calculating a recommended version bump.",
+      "type": "boolean",
+      "default": false
     }
   },
   "required": []

--- a/packages/semver/src/executors/version/testing.ts
+++ b/packages/semver/src/executors/version/testing.ts
@@ -50,11 +50,14 @@ export function createFakeContext({
   project,
   projectRoot,
   workspaceRoot,
+  additionalProjects = []
 }: {
   project: string;
   projectRoot: string;
   workspaceRoot: string;
+  additionalProjects?: {project: string, projectRoot: string}[];
 }): ExecutorContext {
+
   return {
     root: workspaceRoot,
     projectName: project,
@@ -62,7 +65,15 @@ export function createFakeContext({
       version: 2,
       projects: {
         [project]: { root: projectRoot, targets: {} },
+        ...assembleAdditionalProjects(additionalProjects)
       },
     },
   } as ExecutorContext;
+}
+
+function assembleAdditionalProjects(additionalProjects: {project: string, projectRoot: string}[]) {
+  return additionalProjects.reduce((acc, p) => {
+    acc[p.project] = { root: p.projectRoot, targets: {} };
+    return acc;
+  }, {});
 }

--- a/packages/semver/src/executors/version/utils/get-greatest-version-bump.spec.ts
+++ b/packages/semver/src/executors/version/utils/get-greatest-version-bump.spec.ts
@@ -1,0 +1,31 @@
+import { getGreatestVersionBump } from './get-greatest-version-bump';
+
+describe('getGreatestVersionBump', () => {
+  // This should only be used when we're calculating a version bump, which should only be release versions.
+  describe('release versions', () => {
+    it('returns a value when only one value is supplied in the array', () => {
+      const version = getGreatestVersionBump(['0.0.1']);
+      expect(version).toEqual('0.0.1');
+    });
+
+    it('returns the greatest value when the greatest is in the front of the list', () => {
+      const version = getGreatestVersionBump(['1.0.0', '0.0.1', '0.1.0']);
+      expect(version).toEqual('1.0.0');
+    });
+
+    it('returns the greatest value when the greatest is in the middle of the list', () => {
+      const version = getGreatestVersionBump(['0.0.1', '0.1.0', '1.0.0', '0.0.1', '0.1.0']);
+      expect(version).toEqual('1.0.0');
+    });
+
+    it('returns the greatest value when the greatest is at the end of the list', () => {
+      const version = getGreatestVersionBump(['0.0.1', '0.0.1', '0.0.1', '0.0.1', '0.1.0']);
+      expect(version).toEqual('0.1.0');
+    });
+
+    it('returns a value when there\'s no winner', () => {
+      const version = getGreatestVersionBump(['0.0.1', '0.0.1', '0.0.1', '0.0.1']);
+      expect(version).toEqual('0.0.1');
+    });
+  })
+});

--- a/packages/semver/src/executors/version/utils/get-greatest-version-bump.ts
+++ b/packages/semver/src/executors/version/utils/get-greatest-version-bump.ts
@@ -1,0 +1,5 @@
+import { rcompare } from 'semver';
+
+export function getGreatestVersionBump(bumps: string[]) {
+  return [...bumps].sort(rcompare)[0];
+}

--- a/packages/semver/src/executors/version/utils/get-project-dependencies.spec.ts
+++ b/packages/semver/src/executors/version/utils/get-project-dependencies.spec.ts
@@ -1,0 +1,114 @@
+import { execAsync } from './exec-async';
+import { of, throwError } from 'rxjs';
+import { getProjectDependencies } from './get-project-dependencies';
+
+jest.mock('./exec-async');
+
+const printAffectedResponse = {
+  "tasks": [],
+  "projects": [
+    "demo",
+    "demo-e2e"
+  ],
+  "projectGraph": {
+    "nodes": [
+      "demo",
+      "lib1",
+      "lib2",
+      "npm:@mock/npm-lib1",
+      "npm:@mock/npm-lib2"
+    ],
+    "dependencies": {
+      "demo": [
+        {
+          "type": "static",
+          "source": "demo",
+          "target": "npm:@mock/npm-lib1"
+        },
+        {
+          "type": "implicit",
+          "source": "demo",
+          "target": "lib1"
+        },
+        {
+          "type": "static",
+          "source": "demo",
+          "target": "lib2"
+        }
+      ],
+      "lib1": [
+        {
+          "type": "static",
+          "source": "lib1",
+          "target": "npm:@mock/npm-lib1"
+        },
+        {
+          "type": "implicit",
+          "source": "lib1",
+          "target": "lib2"
+        }
+      ],
+      "lib2": [
+        {
+          "type": "static",
+          "source": "lib2",
+          "target": "npm:@mock/npm-lib2"
+        },
+        {
+          "type": "static",
+          "source": "lib2",
+          "target": "lib1"
+        }
+      ],
+      "demo-e2e": [
+        {
+          "type": "implicit",
+          "source": "demo-e2e",
+          "target": "demo"
+        }
+      ]
+    }
+  }
+}
+
+describe('projectDependencies', () => {
+  const mockExecAsync = execAsync as jest.MockedFunction<
+    typeof execAsync
+    >;
+
+  afterEach(() => {
+    mockExecAsync.mockRestore();
+  });
+
+  it('returns a list of libs that the project is dependent on', async () => {
+    mockExecAsync.mockReturnValue(of({ stderr: undefined, stdout: JSON.stringify(printAffectedResponse) }));
+
+    const dependencies = await getProjectDependencies('demo');
+    expect(dependencies).toEqual(['lib1', 'lib2']);
+
+    expect(mockExecAsync).toHaveBeenCalledTimes(1);
+    expect(mockExecAsync).toBeCalledWith('npm', ['run', '-s', 'nx print-affected']);
+  });
+
+  it('returns a sub-dependency', async () => {
+    mockExecAsync.mockReturnValue(of({ stderr: undefined, stdout: JSON.stringify(printAffectedResponse) }));
+
+    const dependencies = await getProjectDependencies('lib1');
+    expect(dependencies).toEqual(['lib2']);
+
+    expect(mockExecAsync).toHaveBeenCalledTimes(1);
+    expect(mockExecAsync).toBeCalledWith('npm', ['run', '-s', 'nx print-affected']);
+  });
+
+  it('handles a failure in retrieving the dependency graph', async () => {
+    mockExecAsync.mockReturnValue(throwError({ stderr: 'thrown error', stdout: undefined }));
+
+    let error;
+    try {
+      await getProjectDependencies('lib1');
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toEqual('thrown error');
+  });
+});

--- a/packages/semver/src/executors/version/utils/get-project-dependencies.ts
+++ b/packages/semver/src/executors/version/utils/get-project-dependencies.ts
@@ -1,0 +1,46 @@
+import { execAsync } from './exec-async';
+
+interface ProjectGraphDependency {
+  type: string;
+  target: string;
+  source: string;
+}
+
+/**
+ * Returns a list of in-repo dependencies based on NX's dependency graph.
+ */
+export async function getProjectDependencies(projectName: string): Promise<string[]> {
+  const dependencyGraph = await getParsedDependencyGraph();
+  return Array.from(assembleDependenciesFromGraph(dependencyGraph, projectName));
+}
+
+async function getParsedDependencyGraph(): Promise<{[key: string]: ProjectGraphDependency[]}> {
+  return new Promise((resolve, reject) => {
+    execAsync('npm', ['run', '-s', 'nx print-affected'])
+      .subscribe({
+        next: output => resolve(JSON.parse(output.stdout).projectGraph.dependencies),
+        error: err => reject(err.stderr)
+      });
+  });
+}
+
+function assembleDependenciesFromGraph(dependencyGraph: {[key: string]: ProjectGraphDependency[]}, projectName: string, traversedNodes: string[] = []): Set<string> {
+    return getProjectsFromDependencies(dependencyGraph[projectName])
+    .reduce((acc, dependency) => {
+      // This if statement keeps us from getting caught in a circular dependency.
+      if (traversedNodes.indexOf(dependency) === -1) {
+        const subDependencies = assembleDependenciesFromGraph(dependencyGraph, dependency, [projectName, ...traversedNodes]);
+        acc = new Set([...acc, dependency, ...subDependencies]);
+      }
+      return acc;
+    }, new Set<string>());
+}
+
+/**
+ * Gets only the dependencies that are in the project. Not NPM packages.
+ */
+function getProjectsFromDependencies(dependencies: ProjectGraphDependency[]): string[] {
+  return dependencies
+    .filter(d => !d.target.startsWith('npm:'))
+    .map(d => d.target);
+}

--- a/packages/semver/src/executors/version/utils/try-bump.spec.ts
+++ b/packages/semver/src/executors/version/utils/try-bump.spec.ts
@@ -78,6 +78,88 @@ describe('tryBump', () => {
     );
   });
 
+  it('should compute the next version based on last version, changes, and dependencies', async () => {
+    mockGetCommits
+      .mockReturnValueOnce(of(['fix: A', 'fix: B']))
+      .mockReturnValueOnce(of(['chore: A', 'chore: B']))
+      .mockReturnValueOnce(of(['fix: A', 'feat: B']));
+
+    /* Mock bump to return "minor". */
+    mockConventionalRecommendedBump
+      .mockImplementation(
+        callbackify(
+          jest.fn().mockResolvedValue({
+            releaseType: 'patch',
+          })
+        )
+      )
+      .mockImplementation(
+        callbackify(
+          jest.fn().mockResolvedValue({
+            releaseType: undefined,
+          })
+        )
+      )
+      .mockImplementation(
+        callbackify(
+          jest.fn().mockResolvedValue({
+            releaseType: 'minor',
+          })
+        )
+      );
+
+    const newVersion = await tryBump({
+      preset: 'angular',
+      projectRoot: '/libs/demo',
+      dependencyRoots: ['/libs/dep1', '/libs/dep2'],
+      tagPrefix: 'v',
+      releaseType: null,
+      preid: null,
+    }).toPromise();
+
+    expect(newVersion).toEqual('2.2.0');
+
+    expect(mockGetCommits).toBeCalledTimes(3);
+    expect(mockGetCommits).toBeCalledWith({
+        projectRoot: '/libs/demo',
+        since: 'v2.1.0',
+      });
+    expect(mockGetCommits).toBeCalledWith({
+        projectRoot: '/libs/dep1',
+        since: 'v2.1.0',
+      });
+    expect(mockGetCommits).toBeCalledWith({
+        projectRoot: '/libs/dep2',
+        since: 'v2.1.0',
+      });
+
+    expect(mockConventionalRecommendedBump).toBeCalledTimes(3);
+    expect(mockConventionalRecommendedBump).toBeCalledWith(
+      {
+        path: '/libs/demo',
+        preset: 'angular',
+        tagPrefix: 'v',
+      },
+      expect.any(Function)
+    );
+    expect(mockConventionalRecommendedBump).toBeCalledWith(
+      {
+        path: '/libs/dep1',
+        preset: 'angular',
+        tagPrefix: 'v',
+      },
+      expect.any(Function)
+    );
+    expect(mockConventionalRecommendedBump).toBeCalledWith(
+      {
+        path: '/libs/dep2',
+        preset: 'angular',
+        tagPrefix: 'v',
+      },
+      expect.any(Function)
+    );
+  });
+
   it('should use given type to calculate next version', async () => {
     mockGetCommits.mockReturnValue(of(['feat: A', 'feat: B']));
 

--- a/packages/semver/src/executors/version/utils/try-bump.ts
+++ b/packages/semver/src/executors/version/utils/try-bump.ts
@@ -65,7 +65,7 @@ If your project is already versioned, please tag the latest release commit with 
           })
         );
       /* Combine the commit lists that are available for the project and
-       * its dependencies (if using --with-deps). */
+       * its dependencies (if using --use-deps). */
       return combineLatest(listOfGetCommits)
         .pipe(
           map((results: string[][]) => {

--- a/packages/semver/src/executors/version/version.ts
+++ b/packages/semver/src/executors/version/version.ts
@@ -9,6 +9,7 @@ import { getPackageFiles, getProjectRoots } from './utils/workspace';
 
 export interface CommonVersionOptions {
   dryRun: boolean;
+  useDeps: boolean;
   newVersion: string;
   noVerify: boolean;
   preset: string;


### PR DESCRIPTION
This adds `--use-deps` as an option to the version command. The changes work in the following way:

1. Retrieve dependency projects
   a. Capture the output from `nx print-affected` command
   b. Parse the returned dependency graph
   c. Traverse dependencies to get a list of the dependencies
2. Pass the list of dependencies to the `tryBump` function
3. Assess if there are affecting commits in the project or any of its dependencies to determine if there should be a change
4. Retrieve the recommended version bumps for the project and its dependencies
5. Use the greatest of the retrieved bumps.