### PR TITLE
Use undefined as default value of versionTagPrefix

### DIFF
--- a/packages/semver/src/executors/version/index.ts
+++ b/packages/semver/src/executors/version/index.ts
@@ -30,8 +30,11 @@ export default function version(
 ): Promise<{ success: boolean }> {
   const workspaceRoot = context.root;
   const preset = 'angular';
-  const tagPrefix = versionTagPrefix ? resolveTagTemplate(versionTagPrefix,
-      { target: context.projectName, projectName: context.projectName })
+  const tagPrefix = versionTagPrefix !== undefined 
+    ? resolveTagTemplate(
+      versionTagPrefix,
+      { target: context.projectName, projectName: context.projectName }
+    )
     : (syncVersions ? 'v' : `${context.projectName}-`);
 
   const projectRoot = getProjectRoot(context);

--- a/packages/semver/src/executors/version/schema.json
+++ b/packages/semver/src/executors/version/schema.json
@@ -60,7 +60,10 @@
     },
     "versionTagPrefix": {
       "description": "Version tag prefix. Defaults are 'v' and '${target}-' for sync and independent modes. ${target} will be replaced with context target value for independent mode.",
-      "type": "string"
+      "oneOf": [
+        { "type": "string" },
+        { "type": "null" }
+      ]
     }
   },
   "required": []


### PR DESCRIPTION
By having default value of versionTagPrefix set to `undefined` we allow setting prefix to empty string `""`.

closes #281 