### PR TITLE
Follow `@commitlint/config-angular`

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           node-version: ${{ matrix.node-version }}
+      - run: yarn commitlint --from=last-release
       - run: yarn nx affected:lint --base=last-release
       - run: yarn nx affected:build --base=last-release
       # @NOTICE find a way to use affected:test with --code-coverage flag (if that possible??)

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx --no-install commitlint --config commitlint.config.js --edit $1
+npx --no-install commitlint --edit $1

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,22 +1,6 @@
 module.exports = {
   extends: ['@commitlint/config-angular'],
   rules: {
-    'type-enum': [
-      2,
-      'always',
-      [
-        'ci',
-        'docs',
-        'feat',
-        'fix',
-        'perf',
-        'refactor',
-        'revert',
-        'test',
-        'wip',
-        'chore',
-      ],
-    ],
     'scope-enum': [
       2,
       'always',

--- a/package.json
+++ b/package.json
@@ -69,11 +69,6 @@
       "path": "cz-conventional-changelog"
     }
   },
-  "commitlint": {
-    "extends": [
-      "@commitlint/config-conventional"
-    ]
-  },
   "dependencies": {},
   "resolutions": {
     "rxjs": "^7.4.0"

--- a/packages/semver/src/generators/install/index.spec.ts
+++ b/packages/semver/src/generators/install/index.spec.ts
@@ -245,27 +245,29 @@ describe('Install generator', () => {
 
         await install(tree, options);
 
-        const packageJson2 = readJson(tree, 'package.json');
-        expect(packageJson2.config.commitizen.path).toEqual('other');
+        expect(readJson(tree, 'package.json').config.commitizen.path).toEqual(
+          'other'
+        );
       });
 
       it('add commitlint to package.json devDepencencies', async () => {
         await install(tree, options);
 
         const packageJson = readJson(tree, 'package.json');
-        expect(packageJson.devDependencies['@commitlint/cli']).toBeDefined();
-        expect(
-          packageJson.devDependencies['@commitlint/config-conventional']
-        ).toBeDefined();
+        expect(packageJson.devDependencies).toContainKeys([
+          '@commitlint/cli',
+          '@commitlint/config-conventional',
+          '@commitlint/config-angular',
+        ]);
       });
 
       it('adds commitlint config to package.json if does not exist', async () => {
         await install(tree, options);
 
-        const packageJson = readJson(tree, 'package.json');
+        const commitlintConfig = readJson(tree, '.commitlintrc.js');
 
-        expect(packageJson.commitlint.extends).toEqual([
-          '@commitlint/config-conventional',
+        expect(commitlintConfig.extends).toEqual([
+          '@commitlint/config-angular',
         ]);
       });
 
@@ -279,9 +281,9 @@ describe('Install generator', () => {
 
         await install(tree, options);
 
-        const packageJson2 = readJson(tree, 'package.json');
-
-        expect(packageJson2.commitlint.extends).toEqual(['other']);
+        expect(readJson(tree, 'package.json').commitlint.extends).toEqual([
+          'other',
+        ]);
       });
 
       it('add husky to package.json devDepencencies', async () => {
@@ -317,15 +319,13 @@ describe('Install generator', () => {
 
         const packageJson = readJson(tree, 'package.json');
 
-        expect(packageJson.devDependencies.commitizen).toBeUndefined();
-        expect(
-          packageJson.devDependencies['cz-conventional-changelog']
-        ).toBeUndefined();
-        expect(packageJson.devDependencies['@commitlint/cli']).toBeUndefined();
-        expect(
-          packageJson.devDependencies['@commitlint/config-conventional']
-        ).toBeUndefined();
-        expect(packageJson.devDependencies.husky).toBeUndefined();
+        expect(packageJson.devDependencies).not.toContainKeys([
+          'commitizen',
+          'cz-conventional-changelog',
+          '@commitlint/cli',
+          '@commitlint/config-conventional',
+          '@commitlint/config-angular',
+        ]);
       });
     });
   });

--- a/packages/semver/src/generators/install/utils/dependencies.ts
+++ b/packages/semver/src/generators/install/utils/dependencies.ts
@@ -1,4 +1,4 @@
-import type { Tree } from '@nrwl/devkit';
+import { readJson, Tree } from '@nrwl/devkit';
 import { addDependenciesToPackageJson } from '@nrwl/devkit';
 import { updateJson } from '@nrwl/devkit';
 import { constants } from 'fs';
@@ -38,8 +38,9 @@ function _addDevDependencies(tree: Tree, options: SchemaOptions) {
       {
         commitizen: '^4.2.4',
         'cz-conventional-changelog': '^3.3.0',
-        '@commitlint/cli': '^13.2.1',
-        '@commitlint/config-conventional': '^13.2.0',
+        '@commitlint/cli': '^14.1.0',
+        '@commitlint/config-conventional': '^14.1.0',
+        '@commitlint/config-angular': '^14.1.0',
         husky: '^7.0.4',
       }
     );
@@ -64,24 +65,31 @@ function _addCommitizenConfig(tree: Tree) {
 }
 
 function _addCommitlintConfig(tree: Tree) {
-  return updateJson(tree, PACKAGE_JSON, (packageJson: PackageJson) => {
-    const hasConfig: boolean =
-      packageJson.commitlint != null ||
-      tree.exists('commitlint.config.js') ||
-      tree.exists('commitlint') ||
-      tree.exists('.commitlintrc.js') ||
-      tree.exists('.commitlintrc.json') ||
-      tree.exists('.commitlintrc.yml');
+  const packageJson = readJson(tree, PACKAGE_JSON);
 
-    if (!hasConfig) {
-      packageJson.commitlint = {
-        ...packageJson.commitlint,
-        extends: ['@commitlint/config-conventional'],
-      };
-    }
+  const hasConfig: boolean =
+    packageJson.commitlint != null ||
+    tree.exists('commitlint.config.js') ||
+    tree.exists('commitlint') ||
+    tree.exists('.commitlintrc.js') ||
+    tree.exists('.commitlintrc.json') ||
+    tree.exists('.commitlintrc.yml');
 
-    return packageJson;
-  });
+  if (!hasConfig) {
+    tree.write(
+      '.commitlintrc.js',
+      JSON.stringify(
+        {
+          extends: ['@commitlint/config-angular'],
+          rules: {},
+        },
+        null,
+        2
+      )
+    );
+  }
+
+  return tree;
 }
 
 function _addHuskyConfig(tree: Tree) {


### PR DESCRIPTION
- Configure commitlint in a dedicated  `.commitlintrc.js` file,
- extends `@commitlint/config-angular` rules
- update commitlint packages
- stick to `@commitlint/config-angular` types for semver linting
- run commitlint in the ci