### PR TITLE
ci: ⚙️ improve CI operations time by 32% in average

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -15,6 +15,7 @@ runs:
     - name: Use Node.js
       uses: actions/setup-node@v2
       with:
+        cache: yarn
         node-version: ${{ inputs.node-version }}
         # This doesn't just set the registry url, but also sets
         # the right configuration in .npmrc that reads NPM token
@@ -22,13 +23,6 @@ runs:
         # It actually creates a .npmrc in a temporary folder
         # and sets the NPM_CONFIG_USERCONFIG environment variable.
         registry-url: https://registry.npmjs.org
-    - name: Cache node modules
-      uses: actions/cache@v2
-      env:
-        cache-name: cache-node-modules
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('./yarn.lock') }}
     - name: yarn install
       shell: bash
       run: yarn --frozen-lockfile --no-progress --non-interactive --prefer-offline


### PR DESCRIPTION
I had the same action to set up my node dependencies as you; I noticed the cache seems not to be working on my workflows. In the face of installing the dependencies, it was taking a considerable amount of time, so I decided to investigate.

After reading the documentation of the action [actions/setup-node](https://github.com/actions/setup-node#readme), I found that they indicate a way to manage the cache, so I decided to try it.

**The result is positive 🟢**, an improvement of 32% on average (at least for lint, build, check commit message and, unit test). You can see all the analysis on the [PR](https://github.com/bikecoders/ngx-deploy-npm/pull/137) that I did for ngx-deploy-npm

---

You can notice the improvement right in this PR


## New workflow

![image](https://user-images.githubusercontent.com/7026066/141073975-c36c254b-ea6c-4023-b770-e696cbb4ea57.png)


## Old Workflow

![image](https://user-images.githubusercontent.com/7026066/141074076-fe10b41d-0d20-4d40-92f1-4ccf5caf265e.png)
