### PR TITLE
fix(semver): handle post target executor errors

### DIFF
--- a/packages/semver/src/executors/version/testing.ts
+++ b/packages/semver/src/executors/version/testing.ts
@@ -4,7 +4,7 @@ import * as rimraf from 'rimraf';
 import * as tmp from 'tmp';
 import { promisify } from 'util';
 
-import type { ExecutorContext } from '@nrwl/devkit';
+import type { ExecutorContext, Target } from '@nrwl/devkit';
 
 export interface TestingWorkspace {
   tearDown(): Promise<void>;
@@ -50,14 +50,17 @@ export function createFakeContext({
   project,
   projectRoot,
   workspaceRoot,
-  additionalProjects = []
+  additionalProjects = [],
 }: {
   project: string;
   projectRoot: string;
   workspaceRoot: string;
-  additionalProjects?: {project: string, projectRoot: string}[];
+  additionalProjects?: {
+    project: string;
+    projectRoot: string;
+    targets?: Record<string, Target>;
+  }[];
 }): ExecutorContext {
-
   return {
     root: workspaceRoot,
     projectName: project,
@@ -65,15 +68,21 @@ export function createFakeContext({
       version: 2,
       projects: {
         [project]: { root: projectRoot, targets: {} },
-        ...assembleAdditionalProjects(additionalProjects)
+        ...assembleAdditionalProjects(additionalProjects),
       },
     },
   } as ExecutorContext;
 }
 
-function assembleAdditionalProjects(additionalProjects: {project: string, projectRoot: string}[]) {
+function assembleAdditionalProjects(
+  additionalProjects: {
+    project: string;
+    projectRoot: string;
+    targets?: Record<string, Target>;
+  }[]
+) {
   return additionalProjects.reduce((acc, p) => {
-    acc[p.project] = { root: p.projectRoot, targets: {} };
+    acc[p.project] = { root: p.projectRoot, targets: p.targets || {} };
     return acc;
-  }, {} as {[project: string]: any});
+  }, {} as { [project: string]: any });
 }

--- a/packages/semver/src/executors/version/utils/post-target.spec.ts
+++ b/packages/semver/src/executors/version/utils/post-target.spec.ts
@@ -15,10 +15,44 @@ describe(executePostTargets.name, () => {
 
   let nextSpy: jest.Mock;
 
+  const additionalProjects = [
+    {
+      project: 'project-a',
+      projectRoot: 'libs/project-a',
+      targets: {
+        test: {
+          project: 'project-a',
+          target: 'test',
+        },
+      },
+    },
+    {
+      project: 'project-b',
+      projectRoot: 'libs/project-b',
+      targets: {
+        test: {
+          project: 'project-b',
+          target: 'test',
+        },
+      },
+    },
+    {
+      project: 'project-c',
+      projectRoot: 'libs/project-c',
+      targets: {
+        test: {
+          project: 'project-c',
+          target: 'test',
+        },
+      },
+    },
+  ];
+
   const context = createFakeContext({
     project: 'test',
     projectRoot: 'libs/test',
     workspaceRoot: '/root',
+    additionalProjects: additionalProjects,
   });
 
   beforeEach(() => {
@@ -35,7 +69,7 @@ describe(executePostTargets.name, () => {
 
   it('should successfully execute post targets', (done) => {
     mockReadTargetOptions.mockReturnValue({
-      optionA: 'optionA'
+      optionA: 'optionA',
     });
 
     executePostTargets({
@@ -119,6 +153,40 @@ describe(executePostTargets.name, () => {
     });
   });
 
+  it('should handle wrong post target project', (done) => {
+    executePostTargets({
+      postTargets: ['project-a:test', 'project-foo:test'],
+      context,
+    }).subscribe({
+      next: nextSpy,
+      error: (error) => {
+        expect(nextSpy).toBeCalledTimes(1);
+        expect(error.toString()).toEqual(
+          `Error: The target project "project-foo" does not exist in your workspace.\nAvailable projects: [test,project-a,project-b,project-c]`
+        );
+        expect(mockRunExecutor).toBeCalledTimes(1);
+        done();
+      },
+    });
+  });
+
+  it('should handle wrong post target target', (done) => {
+    executePostTargets({
+      postTargets: ['project-a:test', 'project-b:foo'],
+      context,
+    }).subscribe({
+      next: nextSpy,
+      error: (error) => {
+        expect(nextSpy).toBeCalledTimes(1);
+        expect(error.toString()).toEqual(
+          `Error: The target name "foo" does not exist.\nAvailable targets for "project-b": [test]`
+        );
+        expect(mockRunExecutor).toBeCalledTimes(1);
+        done();
+      },
+    });
+  });
+
   it('should forward and resolve options', (done) => {
     mockReadTargetOptions.mockReturnValueOnce({
       optionA: 'optionA',
@@ -136,7 +204,7 @@ describe(executePostTargets.name, () => {
       version: '2.0.0',
       dryRun: true,
       num: 42,
-      falseyValue: false
+      falseyValue: false,
     };
 
     executePostTargets({

--- a/packages/semver/src/executors/version/utils/post-target.spec.ts
+++ b/packages/semver/src/executors/version/utils/post-target.spec.ts
@@ -22,7 +22,7 @@ describe(executePostTargets.name, () => {
       targets: {
         test: {
           project: 'project-a',
-          target: 'test',
+          target: '@test',
         },
       },
     },
@@ -32,7 +32,7 @@ describe(executePostTargets.name, () => {
       targets: {
         test: {
           project: 'project-b',
-          target: 'test',
+          target: '@test',
         },
       },
     },
@@ -42,7 +42,7 @@ describe(executePostTargets.name, () => {
       targets: {
         test: {
           project: 'project-c',
-          target: 'test',
+          target: '@test',
         },
       },
     },
@@ -155,33 +155,35 @@ describe(executePostTargets.name, () => {
 
   it('should handle wrong post target project', (done) => {
     executePostTargets({
+      /* The second project "project-foo" is not defined in the workspace. */
       postTargets: ['project-a:test', 'project-foo:test'],
       context,
     }).subscribe({
       next: nextSpy,
       error: (error) => {
         expect(nextSpy).toBeCalledTimes(1);
-        expect(error.toString()).toEqual(
-          `Error: The target project "project-foo" does not exist in your workspace.\nAvailable projects: [test,project-a,project-b,project-c]`
-        );
         expect(mockRunExecutor).toBeCalledTimes(1);
+        expect(error.toString()).toEqual(
+          'Error: The target project "project-foo" does not exist in your workspace. Available projects: "test","project-a","project-b","project-c"'
+        );
         done();
       },
     });
   });
 
-  it('should handle wrong post target target', (done) => {
+  it('should handle wrong post target name', (done) => {
     executePostTargets({
+      /* The second target "foo" is not defined in the workspace. */
       postTargets: ['project-a:test', 'project-b:foo'],
       context,
     }).subscribe({
       next: nextSpy,
       error: (error) => {
         expect(nextSpy).toBeCalledTimes(1);
-        expect(error.toString()).toEqual(
-          `Error: The target name "foo" does not exist.\nAvailable targets for "project-b": [test]`
-        );
         expect(mockRunExecutor).toBeCalledTimes(1);
+        expect(error.toString()).toEqual(
+          'Error: The target name "foo" does not exist. Available targets for "project-b": "test"'
+        );
         done();
       },
     });

--- a/packages/semver/src/executors/version/utils/post-target.ts
+++ b/packages/semver/src/executors/version/utils/post-target.ts
@@ -47,6 +47,7 @@ export function executePostTargets({
   );
 }
 
+/* istanbul ignore next */
 export function _resolveTargetOptions({
   targetOptions = {},
   resolvableOptions,
@@ -73,6 +74,7 @@ export function _resolveTargetOptions({
   );
 }
 
+/* istanbul ignore next */
 export function _checkTargetExist(target: Target, context: ExecutorContext) {
   const project = context.workspace.projects[target.project];
 

--- a/packages/semver/src/executors/version/utils/post-target.ts
+++ b/packages/semver/src/executors/version/utils/post-target.ts
@@ -80,9 +80,9 @@ export function _checkTargetExist(target: Target, context: ExecutorContext) {
     throw new Error(
       `The target project "${
         target.project
-      }" does not exist in your workspace.\nAvailable projects: [${Object.keys(
+      }" does not exist in your workspace. Available projects: ${Object.keys(
         context.workspace.projects
-      )}]`
+      ).map((project) => `"${project}"`)}`
     );
   }
 
@@ -92,9 +92,9 @@ export function _checkTargetExist(target: Target, context: ExecutorContext) {
     throw new Error(
       `The target name "${
         target.target
-      }" does not exist.\nAvailable targets for "${
+      }" does not exist. Available targets for "${
         target.project
-      }": [${Object.keys(project.targets || {})}]`
+      }": ${Object.keys(project.targets || {}).map((target) => `"${target}"`)}`
     );
   }
 }


### PR DESCRIPTION
Fixes jscutlery/semver#372

### Why 

Handle errors originating from `@nrwl/devkit` *read-target-options* when target project does not exist in workspace or when target name is not configured on project

### How

Reuse same logic from *read-target-options* to retrieve project and targets to perform a check before using it

```js
function readTargetOptions({ project, target, configuration }, context) {
    const projectConfiguration = context.workspace.projects[project];
    const targetConfiguration = projectConfiguration.targets[target];
   [...]
}
```