### PR TITLE
feat(semver): releaseCommitMessageFormat option

### DIFF
--- a/packages/semver/src/executors/version/index.e2e.spec.ts
+++ b/packages/semver/src/executors/version/index.e2e.spec.ts
@@ -1040,6 +1040,34 @@ $`)
       );
     });
   });
+
+  describe('--releaseCommitMessageFormat', () => {
+    beforeAll(async () => {
+      testingWorkspace = setupTestingWorkspace(new Map(commonWorkspaceFiles));
+
+      /* Commit changes. */
+      commitChanges();
+
+      /* Run builder. */
+      result = await version(
+        {
+          ...defaultBuilderOptions,
+          releaseCommitMessageFormat: 'chore: 🎸 release {{currentTag}} [skip ci]'
+        },
+        createFakeContext({
+          project: 'workspace',
+          projectRoot: testingWorkspace.root,
+          workspaceRoot: testingWorkspace.root,
+        })
+      );
+    });
+
+    afterAll(() => testingWorkspace.tearDown());
+
+    it('should have the latest commit following the provided format', () => {
+      expect(commitMessage()).toBe('chore: 🎸 release 0.1.0 [skip ci]')
+    });
+  })
 });
 
 function commitChanges() {
@@ -1070,6 +1098,12 @@ function uncommitedChanges() {
       .split('\n')
       /* Remove empty line. */
       .filter((line) => line.length !== 0)
+  );
+}
+
+function commitMessage() {
+  return (
+    execSync('git show -s --format=%s', { encoding: 'utf-8' }).trim()
   );
 }
 

--- a/packages/semver/src/executors/version/index.spec.ts
+++ b/packages/semver/src/executors/version/index.spec.ts
@@ -495,5 +495,23 @@ describe('@jscutlery/semver:version', () => {
       expect(success).toBe(true);
       expect(mockExecutePostTargets).not.toBeCalled();
     });
+
+    it('pass `releaseCommitMessageFormat` through to standard-version', async () => {
+      await version(
+        {
+          ...options,
+          releaseCommitMessageFormat: 'chore(release): {{currentTag}} [skip ci]',
+          postTargets: ['project-a:test'],
+        },
+        context
+      );
+
+      expect(mockStandardVersion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          releaseCommitMessageFormat:
+            'chore(release): {{currentTag}} [skip ci]',
+        })
+      );
+    })
   });
 });

--- a/packages/semver/src/executors/version/index.ts
+++ b/packages/semver/src/executors/version/index.ts
@@ -35,6 +35,7 @@ export default async function version(
     changelogHeader,
     versionTagPrefix,
     postTargets,
+    releaseCommitMessageFormat
   } = normalizeOptions(options);
   const releaseAs = _releaseAs ?? version;
 
@@ -89,6 +90,7 @@ export default async function version(
         projectRoot,
         tagPrefix,
         changelogHeader,
+        releaseCommitMessageFormat
       };
 
       const runStandardVersion$ = defer(() =>
@@ -169,5 +171,6 @@ function normalizeOptions(options: VersionBuilderSchema) {
     changelogHeader: options.changelogHeader,
     versionTagPrefix: options.versionTagPrefix,
     postTargets: options.postTargets,
+    releaseCommitMessageFormat: options.releaseCommitMessageFormat
   };
 }

--- a/packages/semver/src/executors/version/schema.d.ts
+++ b/packages/semver/src/executors/version/schema.d.ts
@@ -24,4 +24,5 @@ export interface VersionBuilderSchema {
   changelogHeader?: string;
   versionTagPrefix?: string;
   postTargets: string[];
+  releaseCommitMessageFormat?: string;
 }

--- a/packages/semver/src/executors/version/schema.json
+++ b/packages/semver/src/executors/version/schema.json
@@ -79,6 +79,10 @@
       "description": "Includes the project's dependencies in calculating a recommended version bump.",
       "type": "boolean",
       "default": false
+    },
+    "releaseCommitMessageFormat": {
+      "description": "A string to be used to format the auto-generated release commit message.",
+      "type": "string"
     }
   },
 

--- a/packages/semver/src/executors/version/version.ts
+++ b/packages/semver/src/executors/version/version.ts
@@ -20,6 +20,7 @@ export interface CommonVersionOptions {
   projectRoot: string;
   tagPrefix: string;
   changelogHeader?: string;
+  releaseCommitMessageFormat?: string;
 }
 
 export function versionWorkspace({
@@ -107,6 +108,7 @@ export function _runStandardVersion({
   preset,
   tagPrefix,
   skipChangelog,
+  releaseCommitMessageFormat,
   changelogHeader = defaultHeader,
 }: {
   bumpFiles: string[];
@@ -129,6 +131,7 @@ export function _runStandardVersion({
     path: projectRoot,
     preset,
     tagPrefix,
+    releaseCommitMessageFormat,
     skip: {
       changelog: skipChangelog,
     },


### PR DESCRIPTION
## Description

This passes the `releaseCommitMessageFormat` through from the options to `standard-verison`

fixes: #333
