### PR TITLE
feat(semver): provide relative notes to post targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ The `postTargets` option declares `my-project:github` target which runs the `@js
 - `dryRun`
 - `remote`
 - `baseBranch`
+- `notes`
 
 #### Built-in post-targets
 

--- a/packages/semver/CHANGELOG.md
+++ b/packages/semver/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+# [2.15.0](https://github.com/wSedlacek/semver/compare/semver-2.14.3...semver-2.15.0) (2021-12-03)
+
+
+### Features
+
+* **semver:** provide relative notes to post targets ([9b3afba](https://github.com/wSedlacek/semver/commit/9b3afbabfed9fe1e52502f1b22697fd971cf0116))
+
+
+
 ## [2.14.3](https://github.com/jscutlery/semver/compare/semver-2.14.2...semver-2.14.3) (2021-11-29)
 
 

--- a/packages/semver/package.json
+++ b/packages/semver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jscutlery/semver",
-  "version": "2.14.3",
+  "version": "2.15.0",
   "description": "Nx plugin for automate versioning and CHANGELOG generation.",
   "private": false,
   "license": "MIT",

--- a/packages/semver/src/executors/github/README.md
+++ b/packages/semver/src/executors/github/README.md
@@ -57,6 +57,31 @@ This executor aims to be used with [post-targets](https://github.com/jscutlery/s
 }
 ```
 
+##### Only new notes
+
+Rather than using the entire changelog on every release as your notes you can use the `notes`
+context provided by `@jscutlery/semver:version` to only include the new changes
+
+```json
+{
+  "targets": {
+    "version": {
+      "executor": "@jscutlery/semver:version",
+      "options": {
+        "postTargets": ["my-project:github"]
+      }
+    },
+    "github": {
+      "executor": "@jscutlery/semver:github",
+      "options": {
+        "tag": "${tag}",
+        "notes": "${notes}"
+      }
+    }
+  }
+}
+```
+
 #### Available Options
 
 | name                        | type       | default     | description                                                     |

--- a/packages/semver/src/executors/version/index.e2e.spec.ts
+++ b/packages/semver/src/executors/version/index.e2e.spec.ts
@@ -1113,6 +1113,53 @@ $`)
       expect(commitMessage()).toBe('chore(release): 0.1.0');
     });
   });
+
+  // The testing workspace isn't really configured for
+  // executors, perhaps using the `new FSTree()` from
+  // and `new Workspace()` @nrwl/toa would give a
+  // more suitable test environment
+  xdescribe('workspace with postTargets', () => {
+    beforeAll(async () => {
+      testingWorkspace = setupTestingWorkspace(new Map(commonWorkspaceFiles));
+
+      /* Commit changes. */
+      commitChanges();
+
+      /* Run builder. */
+      result = await version(
+        {
+          ...defaultBuilderOptions,
+          syncVersions: true,
+          version: 'prerelease',
+          preid: 'beta',
+          postTargets: ['e:github'],
+        },
+        createFakeContext({
+          project: 'workspace',
+          projectRoot: testingWorkspace.root,
+          workspaceRoot: testingWorkspace.root,
+          additionalProjects: [
+            {
+              project: 'e',
+              projectRoot: './libs/e',
+              targets: {
+                github: {
+                  executor: '@nrwl/workspace:run-script',
+                  options: {
+                    script: 'echo ${notes}',
+                  },
+                },
+              },
+            },
+          ],
+        })
+      );
+    });
+
+    afterAll(() => testingWorkspace.tearDown());
+
+    it.todo('should pass in only the new lines from the changelog as ${notes}');
+  });
 });
 
 function commitChanges() {

--- a/packages/semver/src/executors/version/index.spec.ts
+++ b/packages/semver/src/executors/version/index.spec.ts
@@ -80,7 +80,7 @@ describe('@jscutlery/semver:version', () => {
 
     /* Mock Git execution */
     jest.spyOn(git, 'tryPushToGitRemote').mockReturnValue(of(''));
-    jest.spyOn(git, 'addToStage').mockReturnValue(of(''));
+    jest.spyOn(git, 'addToStage').mockReturnValue(of(undefined));
 
     mockExecutePostTargets.mockReturnValue(of(undefined));
 

--- a/packages/semver/src/executors/version/testing.ts
+++ b/packages/semver/src/executors/version/testing.ts
@@ -4,7 +4,7 @@ import * as rimraf from 'rimraf';
 import * as tmp from 'tmp';
 import { promisify } from 'util';
 
-import type { ExecutorContext, Target } from '@nrwl/devkit';
+import type { ExecutorContext, ProjectConfiguration, TargetConfiguration } from '@nrwl/devkit';
 
 export interface TestingWorkspace {
   tearDown(): Promise<void>;
@@ -47,21 +47,24 @@ export function setupTestingWorkspace(
 }
 
 export function createFakeContext({
+  cwd = process.cwd(),
   project,
   projectRoot,
   workspaceRoot,
   additionalProjects = [],
 }: {
+  cwd?: string;
   project: string;
   projectRoot: string;
   workspaceRoot: string;
   additionalProjects?: {
     project: string;
     projectRoot: string;
-    targets?: Record<string, Target>;
+    targets?: Record<string, TargetConfiguration>;
   }[];
 }): ExecutorContext {
   return {
+    cwd: cwd,
     root: workspaceRoot,
     projectName: project,
     workspace: {
@@ -78,11 +81,11 @@ function assembleAdditionalProjects(
   additionalProjects: {
     project: string;
     projectRoot: string;
-    targets?: Record<string, Target>;
+    targets?: Record<string, TargetConfiguration>;
   }[]
 ) {
   return additionalProjects.reduce((acc, p) => {
     acc[p.project] = { root: p.projectRoot, targets: p.targets || {} };
     return acc;
-  }, {} as { [project: string]: any });
+  }, {} as { [project: string]: ProjectConfiguration });
 }

--- a/packages/semver/src/executors/version/utils/diff.spec.ts
+++ b/packages/semver/src/executors/version/utils/diff.spec.ts
@@ -1,0 +1,52 @@
+import { diff } from './diff';
+
+const FILE_BEFORE = `# This is the header
+## This is the second line of the header
+
+change 6
+
+change 5
+change 4
+change 3
+change 2
+change 1
+`;
+
+const FILE_AFTER = `# This is the header
+## This is the second line of the header
+
+change 9
+
+change 8
+change 7
+change 6
+
+change 5
+change 4
+change 3
+change 2
+change 1
+`;
+
+describe('diff', () => {
+  it('should not include the header in the diff', () => {
+    const difference = diff(FILE_BEFORE, FILE_AFTER);
+
+    expect(difference).not.toInclude('# This is the header');
+    expect(difference).not.toInclude(
+      '## This is the second line of the header'
+    );
+  });
+
+  it('should not include changes from before', () => {
+    const difference = diff(FILE_BEFORE, FILE_AFTER);
+    expect(difference).not.toMatch(/change [1-6]/);
+  });
+
+  it('should include changes from after', () => {
+    const difference = diff(FILE_BEFORE, FILE_AFTER);
+    expect(difference).toInclude("change 7");
+    expect(difference).toInclude("change 8");
+    expect(difference).toInclude("change 9");
+  });
+});

--- a/packages/semver/src/executors/version/utils/diff.ts
+++ b/packages/semver/src/executors/version/utils/diff.ts
@@ -1,0 +1,17 @@
+export function diff(before: string, after: string): string {
+  const linesBefore = before.split('\n');
+  const linesAfter = after.split('\n');
+
+  const differentLines: string[] = [];
+
+  let oldIndex = 0;
+  for (const line of linesAfter) {
+    if (line === linesBefore[oldIndex]) {
+      oldIndex += 1;
+    } else {
+      differentLines.push(line);
+    }
+  }
+
+  return differentLines.join('\n');
+}

--- a/packages/semver/src/executors/version/utils/filesystem.spec.ts
+++ b/packages/semver/src/executors/version/utils/filesystem.spec.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import { lastValueFrom } from 'rxjs';
 import { callbackify } from 'util';
-import { readJsonFile } from './filesystem';
+import { readFileIfExists, readJsonFile } from './filesystem';
 
 jest.mock('fs');
 
@@ -28,9 +28,63 @@ describe('readJsonFile', () => {
      * before we subscribe, otherwise the error is not handled. */
     await new Promise(setImmediate);
 
-    expect(lastValueFrom(file$)).rejects.toThrow(
+    await expect(lastValueFrom(file$)).rejects.toThrow(
       'ENOENT: no such file or directory'
     );
     expect(mockReadFile).toBeCalledTimes(1);
+  });
+});
+
+
+describe('readFileIfExists', () => {
+  let mockExists: jest.Mock;
+  let mockReadFile: jest.Mock;
+
+  beforeEach(() => {
+    mockReadFile = jest.fn();
+    jest
+      .spyOn(fs, 'readFile')
+      /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+      .mockImplementation(callbackify(mockReadFile) as any);
+
+    mockExists = jest.fn();
+    jest
+      .spyOn(fs, 'exists')
+      /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+      .mockImplementation(callbackify(mockExists) as any);
+  });
+
+  it('should return an empty string if the file does not exists', async () => {
+    mockExists.mockResolvedValue(false);
+
+    mockReadFile.mockRejectedValue(
+      new Error('ENOENT: no such file or directory')
+    );
+
+    const file$ = readFileIfExists('/unexisting-file');
+
+    /* Wait for all microtasks to finish. */
+    /* We want to make sure that `fs.readFile` is not called
+     * before we subscribe, otherwise the error is not handled. */
+    await new Promise(setImmediate);
+
+    expect(await lastValueFrom(file$)).toBe('');
+  });
+
+  it('should return a fallback value if provided', async () => {
+    mockExists.mockResolvedValue(false);
+
+    mockReadFile.mockRejectedValue(
+      new Error('ENOENT: no such file or directory')
+    );
+
+    const file$ = readFileIfExists('/unexisting-file', 'some fallback');
+
+    /* Wait for all microtasks to finish. */
+    /* We want to make sure that `fs.readFile` is not called
+     * before we subscribe, otherwise the error is not handled. */
+    await new Promise(setImmediate);
+
+    expect(await lastValueFrom(file$)).toBe('some fallback');
   });
 });

--- a/packages/semver/src/executors/version/utils/filesystem.ts
+++ b/packages/semver/src/executors/version/utils/filesystem.ts
@@ -1,10 +1,24 @@
-import { readFile } from 'fs';
-import { defer } from 'rxjs';
-import { map } from 'rxjs/operators';
+import * as fs from 'fs';
+import { defer, of } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
 import { promisify } from 'util';
 
+function exists(filePath: string) {
+  return defer(() => promisify(fs.exists)(filePath))
+}
+
+function readFile(filePath: string) {
+  return defer(() => promisify(fs.readFile)(filePath, 'utf-8'))
+}
+
+export function readFileIfExists(filePath: string, fallback = '') {
+  return exists(filePath).pipe(
+    switchMap((exist) => (exist ? readFile(filePath) : of(fallback)))
+  )
+}
+
 export function readJsonFile(filePath: string) {
-  return defer(() => promisify(readFile)(filePath, 'utf-8')).pipe(
+  return readFile(filePath).pipe(
     map((data) => JSON.parse(data))
   );
 }

--- a/packages/semver/src/executors/version/utils/git.ts
+++ b/packages/semver/src/executors/version/utils/git.ts
@@ -1,7 +1,7 @@
 import { logger } from '@nrwl/devkit';
 import * as gitRawCommits from 'git-raw-commits';
 import { defer, EMPTY, Observable, throwError } from 'rxjs';
-import { catchError, last, map, scan, startWith, tap } from 'rxjs/operators';
+import { catchError, last, map, mapTo, scan, startWith, tap } from 'rxjs/operators';
 
 import { execAsync } from '../../common/exec-async';
 
@@ -102,7 +102,7 @@ export function addToStage({
 
   const gitAddOptions = [...(dryRun ? ['--dry-run'] : []), ...paths];
   return execAsync('git', ['add', ...gitAddOptions]).pipe(
-    map(() => undefined),
+    mapTo(undefined),
     catchError((error) => throwError(() => new Error(error.stderr)))
   );
 }

--- a/packages/semver/src/executors/version/utils/git.ts
+++ b/packages/semver/src/executors/version/utils/git.ts
@@ -95,14 +95,14 @@ export function addToStage({
 }: {
   paths: string[];
   dryRun: boolean;
-}): Observable<string> {
+}): Observable<void> {
   if (paths.length === 0) {
     return EMPTY;
   }
 
   const gitAddOptions = [...(dryRun ? ['--dry-run'] : []), ...paths];
   return execAsync('git', ['add', ...gitAddOptions]).pipe(
-    map((process) => process.stdout),
+    map(() => undefined),
     catchError((error) => throwError(() => new Error(error.stderr)))
   );
 }

--- a/packages/semver/src/executors/version/utils/post-target.spec.ts
+++ b/packages/semver/src/executors/version/utils/post-target.spec.ts
@@ -1,3 +1,4 @@
+import { TargetConfiguration } from '@nrwl/devkit';
 import { runExecutor, readTargetOptions } from '@nrwl/devkit';
 
 import { createFakeContext } from '../testing';
@@ -15,14 +16,17 @@ describe(executePostTargets.name, () => {
 
   let nextSpy: jest.Mock;
 
-  const additionalProjects = [
+  const additionalProjects: {
+    project: string;
+    projectRoot: string;
+    targets?: Record<string, TargetConfiguration>;
+  }[] = [
     {
       project: 'project-a',
       projectRoot: 'libs/project-a',
       targets: {
         test: {
-          project: 'project-a',
-          target: '@test',
+          executor: 'test',
         },
       },
     },
@@ -31,8 +35,7 @@ describe(executePostTargets.name, () => {
       projectRoot: 'libs/project-b',
       targets: {
         test: {
-          project: 'project-b',
-          target: '@test',
+          executor: 'test',
         },
       },
     },
@@ -41,8 +44,7 @@ describe(executePostTargets.name, () => {
       projectRoot: 'libs/project-c',
       targets: {
         test: {
-          project: 'project-c',
-          target: '@test',
+          executor: 'test',
         },
       },
     },


### PR DESCRIPTION
## Description

This makes it so that the newly added notes are provide in the post targets context so that releases don't need to include the entire changelog.

### Dev Notes

I attempted to setup testing for additionalTargets, I got about 70% of the way there fixing several bugs with the test configurations, however I stopped at the executor not being able to be resolved.

I think that using the tools built into `@nrwl/toa` would be more effective at testing this, but I didn't want to go too in depth into refactoring the e2e test with a feature change

fixes: #331