### PR TITLE
Fix | Typo on `notesFile`

### DIFF
--- a/packages/semver/src/executors/github/schema.json
+++ b/packages/semver/src/executors/github/schema.json
@@ -21,7 +21,7 @@
       "type": "string",
       "description": "Release notes."
     },
-    "notesFiles": {
+    "notesFile": {
       "type": "string",
       "description": "Read release notes from file."
     },


### PR DESCRIPTION
# Description
The schema option is named `notesFiles` but docs & executor use `notesFile`