### PR TITLE
feat(semver): filter out prerelease tags if trying to release

### DIFF
--- a/packages/semver/src/executors/version/utils/get-last-version.spec.ts
+++ b/packages/semver/src/executors/version/utils/get-last-version.spec.ts
@@ -20,16 +20,48 @@ describe(getLastVersion.name, () => {
   });
 
   it('should compute current version from previous semver tag', async () => {
-    mockGitSemverTags.mockResolvedValue(['my-lib-2.1.0', 'my-lib-2.0.0', 'my-lib-1.0.0']);
+    mockGitSemverTags.mockResolvedValue([
+      'my-lib-2.1.0',
+      'my-lib-2.0.0',
+      'my-lib-1.0.0',
+    ]);
 
     const tag = await lastValueFrom(getLastVersion({ tagPrefix }));
 
     expect(tag).toEqual('2.1.0');
   });
 
+  it('should compute current version from previous semver prerelease tag', async () => {
+    mockGitSemverTags.mockResolvedValue([
+      'my-lib-2.1.0-beta.0',
+      'my-lib-2.0.0',
+      'my-lib-1.0.0',
+    ]);
+
+    const tag = await lastValueFrom(getLastVersion({ tagPrefix }));
+
+    expect(tag).toEqual('2.1.0-beta.0');
+  });
+
+  it('should compute current version from previous semver release tag', async () => {
+    mockGitSemverTags.mockResolvedValue([
+      'my-lib-2.1.0-beta.0',
+      'my-lib-2.0.0',
+      'my-lib-1.0.0',
+    ]);
+
+    const tag = await lastValueFrom(
+      getLastVersion({ tagPrefix, includePrerelease: false })
+    );
+
+    expect(tag).toEqual('2.0.0');
+  });
+
   it('should throw error if no tag available', async () => {
     mockGitSemverTags.mockResolvedValue([]);
 
-    expect(lastValueFrom(getLastVersion({ tagPrefix }))).rejects.toThrow('No semver tag found');
+    expect(lastValueFrom(getLastVersion({ tagPrefix }))).rejects.toThrow(
+      'No semver tag found'
+    );
   });
 });

--- a/packages/semver/src/executors/version/utils/get-last-version.ts
+++ b/packages/semver/src/executors/version/utils/get-last-version.ts
@@ -8,14 +8,20 @@ import type { Observable } from 'rxjs';
 
 export function getLastVersion({
   tagPrefix,
+  includePrerelease = true,
 }: {
   tagPrefix: string;
+  includePrerelease?: boolean;
 }): Observable<string> {
   return from(
     (promisify(gitSemverTags) as any)({ tagPrefix }) as Promise<string[]>
   ).pipe(
     switchMap((tags: string[]) => {
-      const versions = tags.map((tag) => tag.substring(tagPrefix.length));
+      const versions = tags
+        .map((tag) => tag.substring(tagPrefix.length))
+        .filter((v) =>
+          includePrerelease ? true : semver.prerelease(v) === null
+        );
       const [version] = versions.sort(semver.rcompare);
 
       if (version == null) {

--- a/packages/semver/src/executors/version/utils/try-bump.ts
+++ b/packages/semver/src/executors/version/utils/try-bump.ts
@@ -30,7 +30,10 @@ export function tryBump({
   preid?: string;
 }): Observable<string | null> {
   const initialVersion = '0.0.0';
-  const lastVersion$ = getLastVersion({ tagPrefix }).pipe(
+  const lastVersion$ = getLastVersion({
+    tagPrefix,
+    includePrerelease: releaseType === 'prerelease',
+  }).pipe(
     catchError(() => {
       logger.warn(
         `🟠 No previous version tag found, fallback to version 0.0.0.


### PR DESCRIPTION
This PR makes it possible to get the latest version not from the last tag, but from the last release tag, the problem we were having is that we release a lot of beta versions and when we tried to make a final release it wasn't possible to do it automatically because the last beta tag existed and it would not detect any changes after it.