### PR TITLE
feat(semver): add gitlab releases executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Note that options using the interpolation notation `${variable}` are resolved wi
 #### Built-in post-targets
 
 - [`@jscutlery/semver:github`](https://github.com/jscutlery/semver/blob/main/packages/semver/src/executors/github/README.md) GiHub Release Support
+- [`@jscutlery/semver:gitlab`](https://github.com/jscutlery/semver/blob/main/packages/semver/src/executors/gitlab/README.md) GitLab Release Support
 
 #### Tracking dependencies
 

--- a/packages/semver/builders.json
+++ b/packages/semver/builders.json
@@ -9,6 +9,11 @@
       "implementation": "./src/executors/github/executor",
       "schema": "./src/executors/github/schema.json",
       "description": "github executor"
+    },
+    "gitlab": {
+      "implementation": "./src/executors/gitlab/executor",
+      "schema": "./src/executors/gitlab/schema.json",
+      "description": "gitlab executor"
     }
   },
   "builders": {
@@ -21,6 +26,11 @@
       "implementation": "./src/executors/github/compat",
       "schema": "./src/executors/github/schema.json",
       "description": "github executor"
+    },
+    "gitlab": {
+      "implementation": "./src/executors/gitlab/compat",
+      "schema": "./src/executors/gitlab/schema.json",
+      "description": "gitlab executor"
     }
   }
 }

--- a/packages/semver/src/executors/gitlab/README.md
+++ b/packages/semver/src/executors/gitlab/README.md
@@ -33,7 +33,7 @@ This executor aims to be used with [post-targets](https://github.com/jscutlery/s
       "executor": "@jscutlery/semver:gitlab",
       "options": {
         "tag": "${tag}",
-        "description": "A description"
+        "description": "${notes}"
       }
     }
   }

--- a/packages/semver/src/executors/gitlab/README.md
+++ b/packages/semver/src/executors/gitlab/README.md
@@ -1,0 +1,41 @@
+## @jscutlery/semver:gitlab
+
+An executor for creating GitLab Releases.
+
+### Requirements
+
+This executor requires the [GitLab Release CLI](https://gitlab.com/gitlab-org/release-cli/) to be installed on your machine.
+
+### Usage
+
+#### Run manually
+
+Publish the `v1.0.0` release:
+
+```
+nx run my-project:gitlab --tag_name v1.0.0 [...options]
+```
+
+#### Configuration using post-targets (recommended)
+
+This executor aims to be used with [post-targets](https://github.com/jscutlery/semver#post-targets):
+
+```json
+{
+  "targets": {
+    "version": {
+      "executor": "@jscutlery/semver:version",
+      "options": {
+        "postTargets": ["my-project:gitlab"]
+      }
+    },
+    "github": {
+      "executor": "@jscutlery/semver:gitlab",
+      "options": {
+        "tag_name": "${tag}",
+        "description": "A description"
+      }
+    }
+  }
+}
+```

--- a/packages/semver/src/executors/gitlab/README.md
+++ b/packages/semver/src/executors/gitlab/README.md
@@ -13,7 +13,7 @@ This executor requires the [GitLab Release CLI](https://gitlab.com/gitlab-org/re
 Publish the `v1.0.0` release:
 
 ```
-nx run my-project:gitlab --tag_name v1.0.0 [...options]
+nx run my-project:gitlab --tag v1.0.0 [...options]
 ```
 
 #### Configuration using post-targets (recommended)

--- a/packages/semver/src/executors/gitlab/README.md
+++ b/packages/semver/src/executors/gitlab/README.md
@@ -32,10 +32,22 @@ This executor aims to be used with [post-targets](https://github.com/jscutlery/s
     "github": {
       "executor": "@jscutlery/semver:gitlab",
       "options": {
-        "tag_name": "${tag}",
+        "tag": "${tag}",
         "description": "A description"
       }
     }
   }
 }
 ```
+
+#### Available Options
+
+| name                  | type       | default          | description                                                  |
+| --------------------- | ---------- | ---------------- | ------------------------------------------------------------ |
+| **`--tag`**           | `string`   | `$CI_COMMIT_TAG` | attach the release to the specified tag                      |
+| **`--name`**          | `string`   | `undefined`      | name of the release                                          |
+| **`--assets`**        | `string[]` | `undefined`      | a list of assets to attach new release                       |
+| **`--description`**   | `string`   | `undefined`      | release notes                                                |
+| **`--releasedAt`**    | `string`   | `undefined`      | timestamp which the release will happen/has happened         |
+| **`--ref`**           | `boolean`  | `$CI_COMMIT_SHA` | commit SHA, another tag name, or a branch name               |
+| **`--milestones`**    | `string[]` | `undefined`      | list of milestones to associate the release with             |

--- a/packages/semver/src/executors/gitlab/compat.ts
+++ b/packages/semver/src/executors/gitlab/compat.ts
@@ -1,0 +1,5 @@
+import { convertNxExecutor } from '@nrwl/devkit';
+
+import runExecutor from './executor';
+
+export default convertNxExecutor(runExecutor);

--- a/packages/semver/src/executors/gitlab/executor.spec.ts
+++ b/packages/semver/src/executors/gitlab/executor.spec.ts
@@ -1,0 +1,113 @@
+import { logger } from '@nrwl/devkit';
+import { of, throwError } from 'rxjs';
+
+import { execAsync } from '../common/exec-async';
+import executor from './executor';
+
+import type { GitLabReleaseSchema } from './schema';
+
+jest.mock('../common/exec-async');
+
+const options: GitLabReleaseSchema = {
+  tag: 'v1.0.0',
+};
+
+describe('@jscutlery/semver:gitlab', () => {
+  const mockExec = execAsync as jest.Mock;
+
+  beforeEach(() => {
+    mockExec.mockImplementation(() => {
+      return of({
+        stdout: 'success',
+      });
+    });
+  });
+
+  it('create release with specified --tag', async () => {
+    const output = await executor(options);
+
+    expect(mockExec).toBeCalledWith(
+      'release-cli',
+      expect.arrayContaining(['create', '--tag-name', 'v1.0.0'])
+    );
+    expect(output.success).toBe(true);
+  });
+
+  it('create release with specified --assets', async () => {
+    const output = await executor({ ...options, assets: [{name: "asset1", url: "./dist/package"}] });
+
+    expect(mockExec).toBeCalledWith(
+      'release-cli',
+      expect.arrayContaining(["--assets-link='{\"name\": \"asset1\", \"url\": \"./dist/package\"}'"])
+    );
+    expect(output.success).toBe(true);
+  });
+
+  it('create release with specified --ref', async () => {
+    const output = await executor({ ...options, ref: 'master' });
+
+    expect(mockExec).toBeCalledWith(
+      'release-cli',
+      expect.arrayContaining(['--ref', 'master'])
+    );
+    expect(output.success).toBe(true);
+  });
+
+  it('create release with specified --description', async () => {
+    const output = await executor({ ...options, description: 'add feature' });
+
+    expect(mockExec).toBeCalledWith(
+      'release-cli',
+      expect.arrayContaining(['--description', 'add feature'])
+    );
+    expect(output.success).toBe(true);
+  });
+
+  it('create release with specified --name', async () => {
+    const output = await executor({ ...options, name: 'Title for release' });
+
+    expect(mockExec).toBeCalledWith(
+      'release-cli',
+      expect.arrayContaining(['--name', 'Title for release'])
+    );
+    expect(output.success).toBe(true);
+  });
+
+
+  it('create release with specified --milestones', async () => {
+    const output = await executor({
+      ...options,
+      milestones: ["v1.0.0"],
+    });
+
+    expect(mockExec).toBeCalledWith(
+      'release-cli',
+      expect.arrayContaining(['--milestone', 'v1.0.0'])
+    );
+    expect(output.success).toBe(true);
+  });
+
+  it('create release with specified --releasedAt', async () => {
+    const output = await executor({ ...options, releasedAt: 'XYZ' });
+
+    expect(mockExec).toBeCalledWith(
+      'release-cli',
+      expect.arrayContaining(['--released-at', 'XYZ'])
+    );
+    expect(output.success).toBe(true);
+  });
+
+  it('handle release CLI errors', async () => {
+    mockExec.mockImplementation(() => {
+      return throwError(() => ({
+        stderr: 'something went wrong'
+      }));
+    });
+    jest.spyOn(logger, 'error').mockImplementation();
+
+    const output = await executor(options);
+
+    expect(logger.error).toBeCalled();
+    expect(output.success).toBe(false);
+  });
+});

--- a/packages/semver/src/executors/gitlab/executor.ts
+++ b/packages/semver/src/executors/gitlab/executor.ts
@@ -1,0 +1,41 @@
+import { logger } from '@nrwl/devkit';
+import { lastValueFrom, of } from 'rxjs';
+import { catchError, mapTo } from 'rxjs/operators';
+import { ChildProcessResponse, execAsync } from '../common/exec-async';
+import type { GitLabReleaseSchema } from './schema';
+
+export default async function runExecutor({
+  tag,
+  ref,
+  assets,
+  description,
+  milestones,
+  name,
+  releasedAt,
+}: GitLabReleaseSchema) {
+  const createRelease$ = execAsync('release-cli', [
+    'create',
+    ...['--tag-name', tag],
+    ...(name ? ['--name', name] : []),
+    ...(description ? ['--description', description] : []),
+    ...(milestones
+      ? milestones.map((milestone) => ['--milestone', milestone]).flat()
+      : []),
+    ...(releasedAt ? ['--released-at', releasedAt] : []),
+    ...(ref ? ['--ref', ref] : []),
+    ...(assets
+      ? assets.map(
+          (asset) =>
+            `--assets-link='{"name": "${asset.name}", "url": "${asset.url}"}'`
+        )
+      : []),
+  ]).pipe(
+    mapTo({ success: true }),
+    catchError((response: ChildProcessResponse) => {
+      logger.error(response.stderr);
+      return of({ success: false });
+    })
+  );
+
+  return lastValueFrom(createRelease$);
+}

--- a/packages/semver/src/executors/gitlab/schema.d.ts
+++ b/packages/semver/src/executors/gitlab/schema.d.ts
@@ -1,0 +1,14 @@
+export interface GitLabReleaseSchema {
+  tag: string;
+  ref?: string;
+  assets?: Asset[];
+  description?: string;
+  name?: string;
+  milestones?: string[];
+  releasedAt?: string;
+}
+
+export interface Asset {
+  name: string;
+  url: string;
+}

--- a/packages/semver/src/executors/gitlab/schema.json
+++ b/packages/semver/src/executors/gitlab/schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "cli": "nx",
+  "title": "@jscutlery/semver:gitlab",
+  "description": "",
+  "type": "object",
+  "properties": {
+    "tag": {
+      "type": "string",
+      "description": "The tag the release will be created from [$CI_COMMIT_TAG]"
+    },
+    "ref": {
+      "type": "string",
+      "description": "If tag_name doesn’t exist, the release will be created from ref; it can be a commit SHA, another tag name, or a branch name [$CI_COMMIT_SHA]"
+    },
+    "assets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "URL of the asset."
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the asset."
+          }
+        }
+      },
+      "description": "JSON string representation of an asset link (or an array of asset links)"
+    },
+    "description": {
+      "type": "string",
+      "description": "The description of the release; you can use Markdown. A file can be used to read the description contents, must exist inside the working directory; if it contains any whitespace, it will be treated as a string"
+    },
+    "releasedAt": {
+      "type": "string",
+      "description": "The date when the release will be/was ready; defaults to the current time; expected in ISO 8601 format (2019-03-15T08:00:00Z)"
+    },
+    "name": {
+      "type": "string",
+      "description": "The release name"
+    },
+    "milestone": {
+      "type": "array",
+      "description": "List of the titles of each milestone the release is associated with (e.g. --milestone v1.0 --milestone v1.0-rc); each milestone needs to exist"
+    }
+  },
+  "required": ["tag"]
+}


### PR DESCRIPTION
Hi all,

This is a small PR which adds in a GitLab alternative to the GitHub release executor.

My company is using this package and we love it but we use GitLab for CI/CD so thought it'd be nice to get this functionality added into this extension.

This is a fairly quick draft so happy to receive help/pointers to get this merged.

Thanks!