### PR TITLE
feat(semver): allow empty releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,24 +75,25 @@ nx run workspace:version [...options]
 
 #### Available options
 
-| name                         | type       | default     | description                                      |
-| ---------------------------- | ---------- | ----------- | ------------------------------------------------ |
-| **`--dryRun`**               | `boolean`  | `false`     | run with dry mode                                |
-| **`--noVerify`**             | `boolean`  | `false`     | skip git hooks                                   |
-| **`--push`**                 | `boolean`  | `false`     | push the release against git origin              |
-| **`--syncVersions`**         | `boolean`  | `false`     | lock/sync versions between projects              |
-| **`--skipRootChangelog`**    | `boolean`  | `false`     | skip generating root changelog                   |
-| **`--skipProjectChangelog`** | `boolean`  | `false`     | skip generating project changelog                |
-| **`--origin`**               | `string`   | `'origin'`  | push against git remote repository               |
-| **`--baseBranch`**           | `string`   | `'main'`    | push against git base branch                     |
-| **`--changelogHeader`**      | `string`   | `undefined` | custom Markdown header for changelogs            |
-| **`--releaseAs`**            | `string`   | `undefined` | specify the level of change                      |
-| **`--preid`**                | `string`   | `undefined` | prerelease identifier                            |
-| **`--tagPrefix`**            | `string`   | `undefined` | specify the tag prefix                           |
-| **`--postTargets`**          | `string[]` | `[]`        | specify a list of target to execute post-release |
-| **`--trackDeps`**            | `boolean`  | `false`     | use dependencies when calculating a version bump |
-| **`--commitMessageFormat`**  | `string`   | `undefined` | format the auto-generated message commit         |
-| **`--preset`**               | `string`   | `'angular'` | commit message guideline preset                  |
+| name                         | type       | default     | description                                            |
+| ---------------------------- | ---------- | ----------- | ------------------------------------------------------ |
+| **`--dryRun`**               | `boolean`  | `false`     | run with dry mode                                      |
+| **`--noVerify`**             | `boolean`  | `false`     | skip git hooks                                         |
+| **`--push`**                 | `boolean`  | `false`     | push the release against git origin                    |
+| **`--syncVersions`**         | `boolean`  | `false`     | lock/sync versions between projects                    |
+| **`--skipRootChangelog`**    | `boolean`  | `false`     | skip generating root changelog                         |
+| **`--skipProjectChangelog`** | `boolean`  | `false`     | skip generating project changelog                      |
+| **`--origin`**               | `string`   | `'origin'`  | push against git remote repository                     |
+| **`--baseBranch`**           | `string`   | `'main'`    | push against git base branch                           |
+| **`--changelogHeader`**      | `string`   | `undefined` | custom Markdown header for changelogs                  |
+| **`--releaseAs`**            | `string`   | `undefined` | specify the level of change                            |
+| **`--preid`**                | `string`   | `undefined` | prerelease identifier                                  |
+| **`--tagPrefix`**            | `string`   | `undefined` | specify the tag prefix                                 |
+| **`--postTargets`**          | `string[]` | `[]`        | specify a list of target to execute post-release       |
+| **`--trackDeps`**            | `boolean`  | `false`     | use dependencies when calculating a version bump       |
+| **`--allowEmptyRelease`**    | `boolean`  | `false`     | do a version bump even if library source didn't change |
+| **`--commitMessageFormat`**  | `string`   | `undefined` | format the auto-generated message commit               |
+| **`--preset`**               | `string`   | `'angular'` | commit message guideline preset                        |
 
 #### Overwrite default configuration
 

--- a/packages/semver/src/executors/version/index.ts
+++ b/packages/semver/src/executors/version/index.ts
@@ -46,6 +46,7 @@ export default async function version(
     postTargets,
     commitMessageFormat,
     preset,
+    allowEmptyRelease,
   } = normalizeOptions(options);
   const workspaceRoot = context.root;
   const projectName = context.projectName as string;
@@ -78,6 +79,7 @@ export default async function version(
     releaseType: releaseAs,
     preid,
     syncVersions,
+    allowEmptyRelease,
   });
 
   const action$ = newVersion$.pipe(

--- a/packages/semver/src/executors/version/schema.d.ts
+++ b/packages/semver/src/executors/version/schema.d.ts
@@ -40,6 +40,7 @@ export interface VersionBuilderSchema {
    */
   versionTagPrefix?: string | null;
   postTargets: string[];
+  allowEmptyRelease?: boolean;
   commitMessageFormat?: string;
   preset: 'angular' | 'conventional';
 }

--- a/packages/semver/src/executors/version/schema.json
+++ b/packages/semver/src/executors/version/schema.json
@@ -84,6 +84,11 @@
       "type": "boolean",
       "default": false
     },
+    "allowEmptyRelease": {
+      "description": "Allow bumping versions even if there are no changes in the library.",
+      "type": "boolean",
+      "default": false
+    },
     "commitMessageFormat": {
       "description": "A string to be used to format the auto-generated release commit message.",
       "type": "string"

--- a/packages/semver/src/executors/version/utils/try-bump.spec.ts
+++ b/packages/semver/src/executors/version/utils/try-bump.spec.ts
@@ -308,7 +308,7 @@ describe('tryBump', () => {
     mockConventionalRecommendedBump.mockImplementation(
       callbackify(
         jest.fn().mockResolvedValue({
-          releaseType: undefined,
+          releaseType: 'patch',
         })
       ) as () => void
     );
@@ -322,6 +322,32 @@ describe('tryBump', () => {
     );
 
     expect(newVersion).toBeNull();
+    expect(mockGetCommits).toBeCalledWith({
+      projectRoot: '/libs/demo',
+      since: 'v2.1.0',
+    });
+  });
+
+  it('should try to do a bump even if there are no changes in current path when allowEmptyRelease is true', async () => {
+    mockGetCommits.mockReturnValue(of([]));
+    mockConventionalRecommendedBump.mockImplementation(
+      callbackify(
+        jest.fn().mockResolvedValue({
+          releaseType: 'patch',
+        })
+      ) as () => void
+    );
+
+    const newVersion = await lastValueFrom(
+      tryBump({
+        preset: 'angular',
+        projectRoot: '/libs/demo',
+        tagPrefix: 'v',
+        allowEmptyRelease: true,
+      })
+    );
+
+    expect(newVersion?.version).toEqual('2.1.1');
     expect(mockGetCommits).toBeCalledWith({
       projectRoot: '/libs/demo',
       since: 'v2.1.0',

--- a/packages/semver/src/executors/version/utils/try-bump.ts
+++ b/packages/semver/src/executors/version/utils/try-bump.ts
@@ -100,6 +100,7 @@ export function tryBump({
   preid,
   versionTagPrefix,
   syncVersions,
+  allowEmptyRelease,
 }: {
   preset: string;
   projectRoot: string;
@@ -109,6 +110,7 @@ export function tryBump({
   preid?: string;
   versionTagPrefix?: string | null;
   syncVersions?: boolean;
+  allowEmptyRelease?: boolean;
 }): Observable<NewVersion | null> {
   const { lastVersion$, commits$, lastVersionGitRef$ } = getProjectVersion({
     tagPrefix,
@@ -171,8 +173,12 @@ export function tryBump({
             );
           }
 
-          /* No commits since last release & no dependency updates so don't bump. */
-          if (!dependencyUpdates.length && !commits.length) {
+          /* No commits since last release & no dependency updates so don't bump if the `releastAtLeast` flag is not present. */
+          if (
+            !dependencyUpdates.length &&
+            !commits.length &&
+            !allowEmptyRelease
+          ) {
             return of(null);
           }
 


### PR DESCRIPTION
NX allows for configuring implicit dependencies. NX workspaces come by
default with an implicit dependency on package.json "dependencies" field
and some others.
That makes libraries get built, lint and tested when the NPM
dependencies are updated. E.g. when fixing an audit warning.

Previosly, semver would check for changes on libraries folder and skip
a release if it didn't find any. That meant no new releases of people's
libraries when they updated their dependencies.

With this new flag, people can skip this check and always release their
libraries if they were affected by running:
`nx affected --target=version --allowEmptyRelease --parallel=1`.

This is also useful if people configured custom implicit dependencies.

Closes #477.