### PR TITLE
ci: update deprecated renovate option

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,10 +8,11 @@
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,
-    "automergeType": "branch"
+    "automergeType": "branch",
+    "commitMessageAction": "📦 Lock file maintenance"
   },
   "rangeStrategy": "update-lockfile",
-  "commitMessage": "{{{commitMessagePrefix}}} 📦 {{{commitMessageAction}}} {{{commitMessageTopic}}} {{{commitMessageExtra}}} {{{commitMessageSuffix}}}",
+  "commitMessageAction": "📦",
   "packageRules": [
     {
       "matchPackagePatterns": ["^@angular/", "^@nrwl/", "nx"],


### PR DESCRIPTION
I see that your Depency Dashboard is presenting a warning.

It must be because you are using the deprecated option [`commitMessage`](https://github.com/jscutlery/semver/blob/main/.github/renovate.json#L14) on Renovate's config.

![image](https://user-images.githubusercontent.com/7026066/163105836-eaa93c5a-3aec-485c-b42c-192b8486940c.png)

I already solve it on the ngx-deploy-npm repo. It took me several tries to figure out the proper config, but this is the first PR related to it, and its well-documented -> https://github.com/bikecoders/ngx-deploy-npm/pull/267

You can compare the [current configuration](https://github.com/bikecoders/ngx-deploy-npm/blob/master/renovate.json) on ngx-deploy-npm. You can check the PR's commits structure:
  - https://github.com/bikecoders/ngx-deploy-npm/pull/268
  - https://github.com/bikecoders/ngx-deploy-npm/pull/269

The warning disappeared from the [Dependency Dashboard](https://github.com/bikecoders/ngx-deploy-npm/issues/110)