### PR TITLE
fix: version workspace now stages all changes together

### DIFF
--- a/packages/semver/src/executors/version/utils/git.ts
+++ b/packages/semver/src/executors/version/utils/git.ts
@@ -86,23 +86,13 @@ export function tryPush({
     );
 }
 
-export type AddToStage = {
+export function addToStage({
+  paths,
+  dryRun,
+}: {
   paths: string[];
   dryRun: boolean;
-}
-
-export function mergeAddToStage(stages: AddToStage[], dryRun: boolean): AddToStage {
-  const pathsSet = new Set<string>();
-
-  stages.forEach((stage) => stage.paths.forEach((path) => pathsSet.add(path)));
-
-  return {
-    paths: Array.from(pathsSet),
-    dryRun
-  };
-}
-
-export function addToStage({ paths, dryRun }: AddToStage): Observable<void> {
+}): Observable<void> {
   if (paths.length === 0) {
     return EMPTY;
   }

--- a/packages/semver/src/executors/version/utils/git.ts
+++ b/packages/semver/src/executors/version/utils/git.ts
@@ -86,13 +86,23 @@ export function tryPush({
     );
 }
 
-export function addToStage({
-  paths,
-  dryRun,
-}: {
+export type AddToStage = {
   paths: string[];
   dryRun: boolean;
-}): Observable<void> {
+}
+
+export function mergeAddToStage(stages: AddToStage[], dryRun: boolean): AddToStage {
+  const pathsSet = new Set<string>();
+
+  stages.forEach((stage) => stage.paths.forEach((path) => pathsSet.add(path)));
+
+  return {
+    paths: Array.from(pathsSet),
+    dryRun
+  };
+}
+
+export function addToStage({ paths, dryRun }: AddToStage): Observable<void> {
   if (paths.length === 0) {
     return EMPTY;
   }


### PR DESCRIPTION
Fixed issue where staging changes in versionWorkspace() could occur in parallel could cause git to throw an error related to the lockfile.

Related to #507, #500