### PR TITLE
fix(semver): invalid delimiter for asset

### DIFF
--- a/packages/semver/src/executors/gitlab/executor.spec.ts
+++ b/packages/semver/src/executors/gitlab/executor.spec.ts
@@ -42,7 +42,7 @@ describe('@jscutlery/semver:gitlab', () => {
     expect(mockExec).toBeCalledWith(
       'release-cli',
       expect.arrayContaining([
-        '--assets-link=\'{"name": "asset1", "url": "./dist/package"}\'',
+        '--assets-link', '{"name": "asset1", "url": "./dist/package"}',
       ])
     );
     expect(output.success).toBe(true);

--- a/packages/semver/src/executors/gitlab/executor.ts
+++ b/packages/semver/src/executors/gitlab/executor.ts
@@ -26,8 +26,8 @@ export default async function runExecutor({
     ...(assets
       ? assets.map(
           (asset) =>
-            `--assets-link='{"name": "${asset.name}", "url": "${asset.url}"}'`
-        )
+          ['--assets-link', `{"name": "${asset.name}", "url": "${asset.url}"}`]
+        ).flat()
       : []),
   ]).pipe(
     mapTo({ success: true }),


### PR DESCRIPTION
fixes the problem, that the gitlab-executor throws an "invalid delimiter" error when assets are defined

now we follow the same structure for assets, as we do for milestones in the "release-cli" arguments

```
console.log
    [
      'create',
      '--tag-name',
      '1.2.3',
      '--description',
      '# My Notes',
      `--assets-link='{"name": "first", "url": "asset"}'`,
      `--assets-link='{"name": "second", "url": "asset"}'`
    ]

      at src/executors/gitlab/executor.ts:37:11

  console.error
    Error: time="2022-06-03T08:56:14+02:00" level=info msg="Creating Release..." cli=release-cli command=create name= project-id=12345 ref= server-url="https://...net" tag-name=1.2.3 version=0.11.0
    time="2022-06-03T08:56:14+02:00" level=fatal msg="run app" cli=release-cli error="new CreateReleaseRequest: failed to parse assets: 2 errors occurred:\n\t* invalid delimiter for asset: \"'{\\\"name\\\": \\\"first\\\", \\\"url\\\": \\\"asset\\\"}'\"\n\t* invalid delimiter for asset: \"'{\\\"name\\\": \\\"second\\\", \\\"url\\\": \\\"asset\\\"}'\"\n\n" version=0.11.0
    
        at ...
        at ChildProcess.exithandler (node:child_process:406:5)
        at ChildProcess.emit (node:events:527:28)
        at ChildProcess.emit (node:domain:475:12)
        at maybeClose (node:internal/child_process:1092:16)
        at Socket.<anonymous> (node:internal/child_process:451:11)
        at Socket.emit (node:events:527:28)
        at Socket.emit (node:domain:475:12)
        at Pipe.<anonymous> (node:net:709:12)
```


before:
```ts
const args = [
  'create',
  '--tag-name',
  '1.2.3',
  '--description',
  '# My Notes',
  `--assets-link='{"name": "first", "url": "asset"}'`,
  `--assets-link='{"name": "second", "url": "asset"}'`
]
```

after:
```ts
const args = [
  'create',
  '--tag-name',
  '1.2.3',
  '--description',
  '# My Notes',
  '--assets-link'
  '{"name": "first", "url": "asset"}',
  '--assets-link',
  '{"name": "second", "url": "asset"}'
]
```


