### PR TITLE
fix(semver): fix handling of non-object arrays in options

### DIFF
--- a/packages/semver/src/executors/version/utils/post-target.spec.ts
+++ b/packages/semver/src/executors/version/utils/post-target.spec.ts
@@ -239,6 +239,10 @@ describe(runPostTargets.name, () => {
           },
         ],
       },
+      arrayWithStrings: [
+        "first-${version}",
+        "seconnd-${version}"
+      ]
     });
 
     const templateStringContext = {
@@ -289,6 +293,10 @@ describe(runPostTargets.name, () => {
               },
             ],
           },
+          arrayWithStrings: [
+            "first-2.0.0",
+            "seconnd-2.0.0"
+          ]
         });
         done();
       },

--- a/packages/semver/src/executors/version/utils/post-target.ts
+++ b/packages/semver/src/executors/version/utils/post-target.ts
@@ -73,7 +73,14 @@ export function _getTargetOptions({
     (optionsAccumulator, [option, value]) => {
       const resolvedValue = Array.isArray(value)
         ? value.map((_element) =>
-            _getTargetOptions({ options: _element, context })
+            typeof _element !== "object"
+            ? coerce(
+                createTemplateString(
+                  (_element as number | string | boolean).toString(),
+                  context
+                )
+              )
+            : _getTargetOptions({ options: _element, context })
           )
         : typeof value === 'object'
         ? _getTargetOptions({


### PR DESCRIPTION
fixes a problem with the introduced recursive replacement of template-strings, where arrays of primitive datatypes were handled like an object.