### PR TITLE
fix(semver): deal with unrelated histories (#593)

### DIFF
--- a/packages/semver/src/executors/version/utils/git.spec.ts
+++ b/packages/semver/src/executors/version/utils/git.spec.ts
@@ -212,6 +212,18 @@ describe('git', () => {
         expect.arrayContaining(['rev-list', '--max-parents=0', 'HEAD'])
       );
     });
+
+    it(`should get last listed git commit when multiple unrelated histories' origins exist`, async () => {
+      jest.spyOn(cp, 'exec').mockReturnValue(of('sha1\nsha2\nsha3\n\r\n'));
+
+      const tag = await lastValueFrom(getFirstCommitRef());
+
+      expect(tag).toBe('sha3');
+      expect(cp.exec).toBeCalledWith(
+        'git',
+        expect.arrayContaining(['rev-list', '--max-parents=0', 'HEAD'])
+      );
+    });
   });
 
   describe(createTag.name, () => {

--- a/packages/semver/src/executors/version/utils/git.ts
+++ b/packages/semver/src/executors/version/utils/git.ts
@@ -143,7 +143,11 @@ export function addToStage({
 export function getFirstCommitRef(): Observable<string> {
   return exec('git', ['rev-list', '--max-parents=0', 'HEAD']).pipe(
     map((output) => {
-      return output.trim();
+      return output
+        .split('\n')
+        .map((c) => c.trim())
+        .filter(Boolean)
+        .pop()!;
     })
   );
 }


### PR DESCRIPTION
Hello everyone,

This fixes #593. It does not use any heuristics to select the commit, simply picks the last one returned by `git rev-list --max-parents=0 HEAD`

🎈 