### PR TITLE
test: update deprecated ts-jest configuration

### DIFF
--- a/packages/semver/jest.config.ts
+++ b/packages/semver/jest.config.ts
@@ -2,13 +2,13 @@
 export default {
   displayName: 'semver',
   setupFilesAfterEnv: ['jest-extended/all'],
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-    },
-  },
   transform: {
-    '^.+\\.[tj]sx?$': 'ts-jest/legacy',
+    '^.+\\.[tj]sx?$': [
+      'ts-jest/legacy',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+      },
+    ],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
   coverageDirectory: '../../coverage/packages/semver',


### PR DESCRIPTION
## Current Problem

On `ts-jest` v29:

> Define ts-jest config under globals is now deprecated. Please define the config via transformer config instead.

Currently, on the unit test, there is a [warning](https://github.com/jscutlery/semver/actions/runs/3200656733/jobs/5227816719#step:4:91). 

## New behavior

I updated config `ts-jest` to v29, and the warning is [gone](https://github.com/jscutlery/semver/actions/runs/3202620106/jobs/5231776265#step:4:196). 

## Other info
I made these changes on the ngx-deploy-npm repo 
See [PR 378](https://github.com/bikecoders/ngx-deploy-npm/pull/378)