### PR TITLE
Fixes an error when trying to find the current tag from an non existing pre-release tag

### DIFF
--- a/packages/semver/src/executors/version/utils/get-last-version.spec.ts
+++ b/packages/semver/src/executors/version/utils/get-last-version.spec.ts
@@ -31,6 +31,20 @@ describe(getLastVersion.name, () => {
     expect(tag).toEqual('2.1.0');
   });
 
+  it('should compute current version without a matching prerelease preid', async () => {
+    mockGitSemverTags.mockResolvedValue([
+      'my-lib-2.1.0-add-feature.5',
+      'my-lib-2.0.0',
+      'my-lib-1.0.0',
+    ]);
+
+    const tag = await lastValueFrom(
+      getLastVersion({ tagPrefix, preid: 'new-feature' })
+    );
+
+    expect(tag).toEqual('2.0.0');
+  });
+
   it('should compute current version from previous semver prerelease tag with corresponding preid', async () => {
     mockGitSemverTags.mockResolvedValue([
       'my-lib-2.1.0-z-is-the-last-letter-in-alphabet.0',
@@ -49,7 +63,6 @@ describe(getLastVersion.name, () => {
     );
 
     expect(tag).toEqual('2.1.0-z-is-the-last-letter-in-alphabet.0');
-
     expect(tagWithPreidFeat).toEqual('2.1.0-add-feature.5');
     expect(tagWithPreidFix).toEqual('2.1.0-fix-bug.0');
   });

--- a/packages/semver/src/executors/version/utils/get-last-version.ts
+++ b/packages/semver/src/executors/version/utils/get-last-version.ts
@@ -35,8 +35,7 @@ export function getLastVersion({
         return throwError(() => new Error('No semver tag found'));
       }
 
-      const tag = `${tagPrefix}${version}`;
-      return of(tag.substring(tagPrefix.length));
+      return of(version);
     })
   );
 }

--- a/packages/semver/src/executors/version/utils/get-last-version.ts
+++ b/packages/semver/src/executors/version/utils/get-last-version.ts
@@ -25,10 +25,16 @@ export function getLastVersion({
         .filter((v) => {
           if (includePrerelease) {
             const { prerelease } = semver.parse(v) as SemVer;
+            if (!prerelease[0]) {
+              return true;
+            }
+
             return preid ? prerelease[0] === preid : true;
           }
+
           return semver.prerelease(v) === null;
         });
+
       const [version] = versions.sort(semver.rcompare);
 
       if (version == null) {


### PR DESCRIPTION
This should fix #607 