### PR TITLE
fix: version tagPrefix for dependencies not propagated

### DIFF
--- a/packages/semver/src/executors/version/index.ts
+++ b/packages/semver/src/executors/version/index.ts
@@ -82,6 +82,7 @@ export default async function version(
     projectRoot,
     dependencyRoots,
     tagPrefix,
+    versionTagPrefix,
     releaseType: releaseAs,
     preid,
     syncVersions,


### PR DESCRIPTION
fixes #624 