### PR TITLE
docs(semver): add nx compatibility overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,10 @@ release:
 
 Note that you might need to configure a [deploy key](https://docs.gitlab.com/ee/user/project/deploy_keys/) in order to push to your remote repository.
 
+## Compatibility overview with Nx
+- v2.28.0 > requires `@nrwl/devkit ^15.0.0`
+- v2.23.0 > requires `@nrwl/devkit ^14.0.0` 
+
 ## Changelog
 
 For new features or breaking changes [see the changelog](https://github.com/jscutlery/semver/blob/main/packages/semver/CHANGELOG.md).


### PR DESCRIPTION
This PR will add a compatibility overview to the NX-dependency.

I started to add the overview however for some older versions I'm not completely clear.

I digged through the git history and collected this: 

V1.0.0
"@nrwl/cli": "11.0.1",
"@nrwl/nx-plugin": "^11.0.0",
"@nrwl/tao": "11.0.1",
"@nrwl/workspace": "11.0.1",

2.0.0
"@nrwl/cli": "11.6.2",
"@nrwl/nx-plugin": "11.6.2",
"@nrwl/tao": "11.6.2",
"@nrwl/workspace": "11.6.2",

2.4.0
"@nrwl/cli": "12.5.2",
"@nrwl/nx-plugin": "12.5.2",
"@nrwl/tao": "12.5.2",
"@nrwl/workspace": "12.5.2",

2.12.0
"@nrwl/cli": "13.1.3",
"@nrwl/nx-plugin": "13.1.3",
"@nrwl/tao": "13.1.3",
"@nrwl/workspace": "13.1.3",

means with the mentioned versions some Nx dependencies got bumped.
I'm not sure which of these Nx dependencies where required to run `semver`. 

Do you remember? I could imagine that it is the `@nrwl/nx-plugin` dependency and later on some part of this got split up into it's on `@nrwl/nx-devkit`-package. 

For version 2.28.0 and 2.23.0 it is clearly derivable by the `peerDependencies`. This I already added to the overview