### PR TITLE
feat: add possibility to provide a commit parser config

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Important: merge commits messages are ignored by the tool when calculating next 
 | **`--skipCommit`**           | `boolean`          | `false`     | skips generating a new commit, leaves all changes in index, tag would be put on last commit ([details](https://github.com/jscutlery/semver#skipping-commit))    |
 | **`--commitMessageFormat`**  | `string`           | `undefined` | format the auto-generated message commit ([details](https://github.com/jscutlery/semver#commit-message-customization))                                          |
 | **`--preset`**               | `string \| object` | `'angular'` | customize Conventional Changelog options ([details](https://github.com/jscutlery/semver#customizing-conventional-changelog-options))                            |
+| **`--commitParserOptions`**  | `object`           | `undefined` | customize the commit parserConfig ([details](https://github.com/jscutlery/semver#customizing-the-commit-parser))                                                |
 
 #### Overwrite default configuration
 
@@ -132,6 +133,25 @@ The preset is highly configurable, following the [conventional-changelog configu
 ```
 
 See [conventional-changelog-config-spec](https://github.com/conventional-changelog/conventional-changelog-config-spec) for available
+configuration options.
+
+#### Customizing the commit parser
+
+You may customize the config for the commit parser. This can be helpful when you are using an adapted version of conventional commit for instance.
+
+```json
+{
+  "executor": "@jscutlery/semver:version",
+  "options": {
+    "commitParserOptions": {
+      "headerPattern": "^([A-Z]{3,}-\\d{1,5}):? (chore|build|ci|docs|feat|fix|perf|refactor|test)(?:\\(([\\w-]+)\\))?\\S* (.+)$",
+      "headerCorrespondence": ["ticketReference", "type", "scope", "subject"]
+    }
+  }
+}
+```
+
+See the [conventional-commits-parse](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser#options) specification for available
 configuration options.
 
 #### Version calculation

--- a/packages/semver/src/executors/version/index.ts
+++ b/packages/semver/src/executors/version/index.ts
@@ -48,7 +48,9 @@ export default async function version(
     allowEmptyRelease,
     skipCommitTypes,
     skipCommit,
+    commitParserOptions,
   } = _normalizeOptions(options);
+
   const workspaceRoot = context.root;
   const projectName = context.projectName as string;
 
@@ -78,6 +80,7 @@ export default async function version(
   });
   const projectRoot = getProject(context).root;
   const newVersion$ = tryBump({
+    commitParserOptions,
     preset,
     projectRoot,
     dependencyRoots,
@@ -236,6 +239,7 @@ function _normalizeOptions(options: VersionBuilderSchema) {
     changelogHeader: options.changelogHeader ?? defaultHeader,
     versionTagPrefix: options.tagPrefix ?? options.versionTagPrefix,
     commitMessageFormat: options.commitMessageFormat as string,
+    commitParserOptions: options.commitParserOptions,
     skipCommit: options.skipCommit as boolean,
     preset:
       options.preset === 'conventional'

--- a/packages/semver/src/executors/version/schema.d.ts
+++ b/packages/semver/src/executors/version/schema.d.ts
@@ -1,4 +1,8 @@
 import ConventionalChangelogConfigSpec from '@types/conventional-changelog-config-spec';
+import type { Options as CommitParserOptions } from 'conventional-commits-parser';
+
+export { CommitParserOptions };
+
 export type ReleaseIdentifier =
   | 'patch'
   | 'minor'
@@ -44,6 +48,7 @@ export interface VersionBuilderSchema {
   skipCommitTypes?: string[];
   commitMessageFormat?: string;
   preset: Preset;
+  commitParserOptions?: CommitParserOptions;
 }
 
 export interface WriteChangelogConfig {

--- a/packages/semver/src/executors/version/schema.json
+++ b/packages/semver/src/executors/version/schema.json
@@ -134,6 +134,49 @@
           "$ref": "#/definitions/conventionalChangelogConfiguration"
         }
       ]
+    },
+    "commitParserOptions": {
+      "description": "The options passed to the commit parser.",
+      "type": "object",
+      "properties": {
+        "mergePattern": {
+          "description": "Pattern to match merge headers. EG: branch merge, GitHub or GitLab like pull requests headers. When a merge header is parsed, the next line is used for conventional header parsing.",
+          "type": "string"
+        },
+        "mergeCorrespondence": {
+          "description": "Used to define what capturing group of mergePattern.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "Merge correspondence types"
+          }
+        },
+        "headerPattern": {
+          "description": "Used to match header pattern.",
+          "type": "string"
+        },
+        "headerCorrespondence": {
+          "description": "Used to define what capturing group of headerPattern captures what header part. The order of the array should correspond to the order of headerPattern's capturing group. If the part is not captured it is null.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "Header correspondence types"
+          }
+        },
+        "fieldPattern": {
+          "description": "Pattern to match other fields.",
+          "type": "string"
+        },
+        "revertPattern": {
+          "description": "Pattern to match what this commit reverts.",
+          "type": "string"
+        },
+        "commentChar": {
+          "description": "What commentChar to use. By default it is null, so no comments are stripped. Set to # if you pass the contents of .git/COMMIT_EDITMSG directly.",
+          "type": "string"
+        }
+      },
+      "required": []
     }
   },
   "definitions": {


### PR DESCRIPTION
Previously it was impossible to use anything but
conventional commits because the header pattern could not be modified from the outside. Now you can provide you custom config through the option `commitParserOptions`. This is intended for use cases where ticket numbers are prefixing the conventional commit message.