### PR TITLE
feat: create CHANGELOG.md when setting up semver for a project

### DIFF
--- a/packages/semver/src/generators/install/__files/CHANGELOG.md
+++ b/packages/semver/src/generators/install/__files/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/packages/semver/src/generators/install/index.spec.ts
+++ b/packages/semver/src/generators/install/index.spec.ts
@@ -328,4 +328,51 @@ describe('Install generator', () => {
       ]);
     });
   });
+
+  describe('Create Changelog', () => {
+    const options = {
+      ...defaultOptions,
+      syncVersions: false,
+    };
+
+    beforeEach(async () => {
+      addProjectConfiguration(tree, 'lib1', {
+        root: 'libs/lib1',
+        sourceRoot: 'libs/lib1/src',
+        targets: {},
+      });
+
+      writeJson(tree, 'libs/lib1/tsconfig.json', {
+        files: [],
+        include: [],
+        references: [],
+      });
+
+      addProjectConfiguration(tree, 'lib2', {
+        root: 'libs/lib2',
+        sourceRoot: 'libs/lib1/src',
+        targets: {},
+      });
+
+      writeJson(tree, 'libs/lib2/tsconfig.json', {
+        files: [],
+        include: [],
+        references: [],
+      });
+
+      jest.spyOn(inquirer, 'prompt').mockResolvedValue({ projects: ['lib1'] });
+    });
+
+    afterEach(() =>
+      (
+        inquirer.prompt as jest.MockedFunction<typeof inquirer.prompt>
+      ).mockRestore()
+    );
+    it('should create CHANGELOG.md in lib1', async () => {
+      await install(tree, { ...options, projects: ['lib1', 'lib2'] });
+
+      expect(tree.exists('libs/lib1/CHANGELOG.md')).toBeTrue();
+      expect(tree.exists('libs/lib2/CHANGELOG.md')).toBeTrue();
+    });
+  });
 });

--- a/packages/semver/src/generators/install/index.spec.ts
+++ b/packages/semver/src/generators/install/index.spec.ts
@@ -51,33 +51,14 @@ describe('Install generator', () => {
       ...defaultOptions,
       syncVersions: false,
     };
+    const { projects, projectName1, projectName2 } = createProjectNames();
 
     beforeEach(async () => {
-      addProjectConfiguration(tree, 'lib1', {
-        root: 'libs/lib1',
-        sourceRoot: 'libs/lib1/src',
-        targets: {},
-      });
+      addProjects(tree, projects);
 
-      writeJson(tree, 'libs/lib1/tsconfig.json', {
-        files: [],
-        include: [],
-        references: [],
-      });
-
-      addProjectConfiguration(tree, 'lib2', {
-        root: 'libs/lib2',
-        sourceRoot: 'libs/lib1/src',
-        targets: {},
-      });
-
-      writeJson(tree, 'libs/lib2/tsconfig.json', {
-        files: [],
-        include: [],
-        references: [],
-      });
-
-      jest.spyOn(inquirer, 'prompt').mockResolvedValue({ projects: ['lib1'] });
+      jest
+        .spyOn(inquirer, 'prompt')
+        .mockResolvedValue({ projects: [projectName1] });
     });
 
     afterEach(() =>
@@ -89,14 +70,16 @@ describe('Install generator', () => {
     it('should prompt user to select which projects should be versioned', async () => {
       await install(tree, options);
 
-      const lib1 = readJson(tree, 'libs/lib1/project.json');
-      const lib2 = readJson(tree, 'libs/lib2/project.json');
+      const lib1 = findJson(tree, projectName1, 'project.json');
+      const lib2 = findJson(tree, projectName2, 'project.json');
 
       expect(inquirer.prompt).toBeCalledWith(
         expect.objectContaining({
           name: 'projects',
           type: 'checkbox',
-          choices: expect.arrayContaining([{ name: 'lib1', checked: true }]),
+          choices: expect.arrayContaining([
+            { name: projectName1, checked: true },
+          ]),
         })
       );
       /* Project "lib1" selected by the prompt. */
@@ -112,10 +95,10 @@ describe('Install generator', () => {
     });
 
     it('should use --projects option', async () => {
-      await install(tree, { ...options, projects: ['lib2'] });
+      await install(tree, { ...options, projects: [projectName2] });
 
-      const lib1 = readJson(tree, 'libs/lib1/project.json');
-      const lib2 = readJson(tree, 'libs/lib2/project.json');
+      const lib1 = findJson(tree, projectName1, 'project.json');
+      const lib2 = findJson(tree, projectName2, 'project.json');
 
       expect(inquirer.prompt).not.toBeCalled();
       expect(lib1.targets.version).toBeUndefined();
@@ -129,14 +112,12 @@ describe('Install generator', () => {
     });
 
     it('should forward --baseBranch option to all projects', async () => {
-      jest
-        .spyOn(inquirer, 'prompt')
-        .mockResolvedValue({ projects: ['lib1', 'lib2'] });
+      jest.spyOn(inquirer, 'prompt').mockResolvedValue({ projects: projects });
 
       await install(tree, { ...options, baseBranch: 'master' });
 
-      const lib1 = readJson(tree, 'libs/lib1/project.json');
-      const lib2 = readJson(tree, 'libs/lib2/project.json');
+      const lib1 = findJson(tree, projectName1, 'project.json');
+      const lib2 = findJson(tree, projectName2, 'project.json');
 
       expect(lib1.targets).toEqual(
         expect.objectContaining({
@@ -176,7 +157,7 @@ describe('Install generator', () => {
         await install(tree, { ...defaultOptions, preset: 'conventional' });
 
         const packageJson = readJson(tree, 'package.json');
-        const lib1 = readJson(tree, 'libs/lib1/project.json');
+        const lib1 = findJson(tree, projectName1, 'project.json');
 
         expect(packageJson.devDependencies).toContainKeys([
           '@commitlint/cli',
@@ -196,7 +177,7 @@ describe('Install generator', () => {
         await install(tree, { ...defaultOptions, preset: 'angular' });
 
         const packageJson = readJson(tree, 'package.json');
-        const lib1 = readJson(tree, 'libs/lib1/project.json');
+        const lib1 = findJson(tree, projectName1, 'project.json');
 
         expect(packageJson.devDependencies).toContainKeys([
           '@commitlint/cli',
@@ -215,7 +196,7 @@ describe('Install generator', () => {
       it('should install angular config', async () => {
         await install(tree, { ...defaultOptions, preset: 'conventional' });
 
-        const lib1 = readJson(tree, 'libs/lib1/project.json');
+        const lib1 = findJson(tree, projectName1, 'project.json');
 
         expect(lib1.targets).toEqual(
           expect.objectContaining({
@@ -334,33 +315,14 @@ describe('Install generator', () => {
       ...defaultOptions,
       syncVersions: false,
     };
+    const { projects, projectName1, projectName2 } = createProjectNames();
 
     beforeEach(async () => {
-      addProjectConfiguration(tree, 'lib1', {
-        root: 'libs/lib1',
-        sourceRoot: 'libs/lib1/src',
-        targets: {},
-      });
+      addProjects(tree, projects);
 
-      writeJson(tree, 'libs/lib1/tsconfig.json', {
-        files: [],
-        include: [],
-        references: [],
-      });
-
-      addProjectConfiguration(tree, 'lib2', {
-        root: 'libs/lib2',
-        sourceRoot: 'libs/lib1/src',
-        targets: {},
-      });
-
-      writeJson(tree, 'libs/lib2/tsconfig.json', {
-        files: [],
-        include: [],
-        references: [],
-      });
-
-      jest.spyOn(inquirer, 'prompt').mockResolvedValue({ projects: ['lib1'] });
+      jest
+        .spyOn(inquirer, 'prompt')
+        .mockResolvedValue({ projects: [projectName1] });
     });
 
     afterEach(() =>
@@ -369,10 +331,42 @@ describe('Install generator', () => {
       ).mockRestore()
     );
     it('should create CHANGELOG.md in lib1', async () => {
-      await install(tree, { ...options, projects: ['lib1', 'lib2'] });
+      await install(tree, { ...options, projects: projects });
 
-      expect(tree.exists('libs/lib1/CHANGELOG.md')).toBeTrue();
-      expect(tree.exists('libs/lib2/CHANGELOG.md')).toBeTrue();
+      expect(findProjectFile(tree, projectName1, 'CHANGELOG.md')).toBeTrue();
+      expect(findProjectFile(tree, projectName2, 'CHANGELOG.md')).toBeTrue();
     });
   });
 });
+
+function createProjectNames() {
+  const projectName1 = 'lib1';
+  const projectName2 = 'lib2';
+  const projects = [projectName1, projectName2];
+
+  return { projects, projectName1, projectName2 };
+}
+
+function findProjectFile(tree: Tree, projectName: string, fileName: string) {
+  return tree.exists(`libs/${projectName}/${fileName}`);
+}
+
+function findJson(tree: Tree, projectName: string, fileName: string) {
+  return readJson(tree, `libs/${projectName}/${fileName}`);
+}
+
+function addProjects(tree: Tree, projectNames: string[]) {
+  projectNames.forEach((projectName) => {
+    addProjectConfiguration(tree, projectName, {
+      root: `libs/${projectName}`,
+      sourceRoot: `libs/${projectName}/src`,
+      targets: {},
+    });
+
+    writeJson(tree, `libs/${projectName}/tsconfig.json`, {
+      files: [],
+      include: [],
+      references: [],
+    });
+  });
+}

--- a/packages/semver/src/generators/install/index.spec.ts
+++ b/packages/semver/src/generators/install/index.spec.ts
@@ -330,11 +330,12 @@ describe('Install generator', () => {
         inquirer.prompt as jest.MockedFunction<typeof inquirer.prompt>
       ).mockRestore()
     );
-    it('should create CHANGELOG.md in lib1', async () => {
+    it('should create CHANGELOG.md in lib1 and lib2', async () => {
       await install(tree, { ...options, projects: projects });
 
       expect(findProjectFile(tree, projectName1, 'CHANGELOG.md')).toBeTrue();
       expect(findProjectFile(tree, projectName2, 'CHANGELOG.md')).toBeTrue();
+      expect(findProjectFile(tree, 'lib3', 'CHANGELOG.md')).toBeFalse();
     });
   });
 });

--- a/packages/semver/src/generators/install/utils/create-changelog.ts
+++ b/packages/semver/src/generators/install/utils/create-changelog.ts
@@ -1,6 +1,9 @@
 import { generateFiles, joinPathFragments, Tree } from '@nx/devkit';
 
-export function addChangelog(tree: Tree, libraryRoot: string) {
+export function createChangelog(tree: Tree, libraryRoot: string) {
+  if (tree.exists(joinPathFragments(libraryRoot, 'CHANGELOG.md'))) {
+    return;
+  }
   generateFiles(
     tree,
     joinPathFragments(__dirname, '../__files'), // path to the file templates

--- a/packages/semver/src/generators/install/utils/create-changelog.ts
+++ b/packages/semver/src/generators/install/utils/create-changelog.ts
@@ -1,0 +1,10 @@
+import { generateFiles, joinPathFragments, Tree } from '@nx/devkit';
+
+export function addChangelog(tree: Tree, libraryRoot: string) {
+  generateFiles(
+    tree,
+    joinPathFragments(__dirname, '../__files'), // path to the file templates
+    libraryRoot,
+    {}
+  );
+}

--- a/packages/semver/src/generators/install/utils/workspace.ts
+++ b/packages/semver/src/generators/install/utils/workspace.ts
@@ -10,7 +10,7 @@ import { createPrompt } from './prompt';
 
 import type { Tree } from '@nx/devkit';
 import type { SchemaOptions } from '../schema';
-import { addChangelog } from './create-changelog';
+import { createChangelog } from './create-changelog';
 
 export type ProjectDefinition = ProjectConfiguration & { projectName: string };
 
@@ -35,7 +35,7 @@ export function updateProjects(
       updateProjectConfiguration(tree, projectName, project);
       const libraryRoot = readProjectConfiguration(tree, projectName).root;
 
-      addChangelog(tree, libraryRoot);
+      createChangelog(tree, libraryRoot);
     }
   });
 }

--- a/packages/semver/src/generators/install/utils/workspace.ts
+++ b/packages/semver/src/generators/install/utils/workspace.ts
@@ -2,6 +2,7 @@ import {
   getProjects,
   updateProjectConfiguration,
   type ProjectConfiguration,
+  readProjectConfiguration,
 } from '@nx/devkit';
 
 import { createTarget } from './create-target';
@@ -9,6 +10,7 @@ import { createPrompt } from './prompt';
 
 import type { Tree } from '@nx/devkit';
 import type { SchemaOptions } from '../schema';
+import { addChangelog } from './create-changelog';
 
 export type ProjectDefinition = ProjectConfiguration & { projectName: string };
 
@@ -30,8 +32,10 @@ export function updateProjects(
     if (predicate(projectName)) {
       const targets = project.targets ?? {};
       targets.version = createTarget(options);
-
       updateProjectConfiguration(tree, projectName, project);
+      const libraryRoot = readProjectConfiguration(tree, projectName).root;
+
+      addChangelog(tree, libraryRoot);
     }
   });
 }


### PR DESCRIPTION
This will close #711 

When `jscutlery/semver` is added to a project it will now create a `CHANGELOG.md` file.

~~Please note that I will still need to clean up this PR a bit (e.g. I did for now introduce some duplication in the spec-file). But of course feel free to already give feedback.~~

PR is now ready. 