### PR TITLE
docs: improve postTargets option behavior documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,9 @@ Contextual variables resolved by this option:
 - `previousTag` previous version tag
 - `dryRun` dry run mode
 
+> [!NOTE]
+> The specified targets are going to be executed as is, without triggering any dependencies. It will not trigger the target's `dependsOn` and Nx caching is not considered
+
 #### Built-in post-targets
 
 - [`@jscutlery/semver:github`](https://github.com/jscutlery/semver/blob/main/packages/semver/src/executors/github/README.md) GiHub Release Support


### PR DESCRIPTION
Since the `postTargets` option uses `runExecutor` [under the hood](https://github.com/jscutlery/semver/blob/main/packages/semver/src/executors/version/utils/post-target.ts#L38), it would be nice to indicate the expected behavior to the users. `runExecutor` is not the same as running the target on the Nx CLI; it calls the target as it, without running any dependency or taking Nx Cache into account.

That behavior is not documented, but [according to the Nx Team](https://github.com/nrwl/nx/issues/19531#issuecomment-1760343458) that's the expected behavior.
> runExecutor runs a specific executor. It doesn't spawn the task orchestrator or any of that, so dependencies are not ran and caching is not considered.
