### PR TITLE
fix(semver): migrate husky to v9 in npm prepare script

### DIFF
--- a/packages/semver/src/generators/install/index.spec.ts
+++ b/packages/semver/src/generators/install/index.spec.ts
@@ -323,7 +323,7 @@ describe('@jscutlery/semver:install', () => {
       const packageJson = readJson(tree, 'package.json');
 
       expect(tree.exists('.husky/commit-msg')).toEqual(true);
-      expect(packageJson.scripts.prepare).toEqual('husky install');
+      expect(packageJson.scripts.prepare).toEqual('husky');
     });
 
     it('does not add husky config if exists', async () => {

--- a/packages/semver/src/generators/install/utils/dependencies.ts
+++ b/packages/semver/src/generators/install/utils/dependencies.ts
@@ -92,7 +92,7 @@ function _addHuskyConfig(tree: Tree) {
     if (!hasHusky) {
       packageJson.scripts = {
         ...packageJson.scripts,
-        ...{ prepare: 'husky install' },
+        ...{ prepare: 'husky' },
       };
     }
 


### PR DESCRIPTION
Reference: https://github.com/typicode/husky/releases/tag/v9.0.1