### PR TITLE
fix: pass package.json path through to `conventional-changelog`

### DIFF
--- a/packages/semver/src/executors/version/utils/conventional-commit.ts
+++ b/packages/semver/src/executors/version/utils/conventional-commit.ts
@@ -1,3 +1,4 @@
+import * as path from 'node:path';
 import * as conventionalChangelog from 'conventional-changelog';
 import { WriteChangelogConfig } from '../schema';
 
@@ -12,7 +13,7 @@ export function createConventionalCommitStream(
       ...(typeof config.preset === 'object' ? { config: config.preset } : {}),
       tagPrefix: config.tagPrefix,
       pkg: {
-        path: config.projectRoot,
+        path: path.join(config.projectRoot, 'package.json'),
       },
     },
     { version: newVersion },


### PR DESCRIPTION
Passing the project root of the Nx project (a directory) always fails, as the code in `conventional-changelog` is [expecting a file path](https://github.com/conventional-changelog/conventional-changelog/blob/conventional-changelog-v5.1.0/packages/conventional-changelog-core/lib/merge-config.js#L114). So we need to explicitly pass the package.json path.