### PR TITLE
feat: added option to skip stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ nx run workspace:version [...options]
 | **`--allowEmptyRelease`**    | `boolean`          | `false`     | force a patch increment even if library source didn't change                                                                                                    |
 | **`--skipCommitTypes`**      | `string[]`         | `[]`        | treat commits with specified types as non invoking version bump ([details](https://github.com/jscutlery/semver#skipping-release-for-specific-types-of-commits)) |
 | **`--skipCommit`**           | `boolean`          | `false`     | skips generating a new commit, leaves all changes in index, tag would be put on last commit ([details](https://github.com/jscutlery/semver#skipping-commit))    |
+| **`--skipStage`**            | `boolean`          | `false`     | skips add to git stage, useful when you want to run nx cmd in parallel ([details](https://github.com/jscutlery/semver#skipping-stage))                          |
 | **`--commitMessageFormat`**  | `string`           | `undefined` | format the auto-generated message commit ([details](https://github.com/jscutlery/semver#commit-message-customization))                                          |
 | **`--preset`**               | `string \| object` | `'angular'` | customize Conventional Changelog options ([details](https://github.com/jscutlery/semver#customizing-conventional-changelog))                                    |
 | **`--commitParserOptions`**  | `object`           | `undefined` | customize the commit parserConfig ([details](https://github.com/jscutlery/semver#customizing-the-commit-parser))                                                |
@@ -283,6 +284,10 @@ would produce a patch bump.
 In some cases, your release process relies only on tags and you don't want a new commit with version bumps and changelog updates to be made.
 To achieve this, you can provide the `--skipCommit` flag and changes made by the library would stay in the index without committing.
 The tag for the new version would be put on the last existing commit.
+
+### Skipping Stage
+
+In case you want to run nx cmd in parallel, you can provide the `--skipStage` flag and it will not add to git stage - since that requires a git-lock, this has to be used together with `--skipCommit` and `--skipTag` and not with `--push`, all for the same reason they will require a git-lock.
 
 ### Triggering executors post-release
 

--- a/packages/semver/src/executors/version/index.ts
+++ b/packages/semver/src/executors/version/index.ts
@@ -48,6 +48,7 @@ export default async function version(
     allowEmptyRelease,
     skipCommitTypes,
     skipCommit,
+    skipStage,
     commitParserOptions,
   } = _normalizeOptions(options);
 
@@ -135,6 +136,7 @@ export default async function version(
         commitMessage,
         dependencyUpdates,
         skipCommit,
+        skipStage,
         workspace: context.projectsConfigurations,
       };
 
@@ -241,6 +243,7 @@ function _normalizeOptions(options: VersionBuilderSchema) {
     commitMessageFormat: options.commitMessageFormat as string,
     commitParserOptions: options.commitParserOptions,
     skipCommit: options.skipCommit as boolean,
+    skipStage: options.skipStage as boolean,
     preset: (options.preset === 'conventional'
       ? 'conventionalcommits'
       : options.preset || 'angular') as PresetOpt,

--- a/packages/semver/src/executors/version/schema.d.ts
+++ b/packages/semver/src/executors/version/schema.d.ts
@@ -33,6 +33,7 @@ export interface VersionBuilderSchema {
   postTargets: string[];
   allowEmptyRelease?: boolean;
   skipCommitTypes?: string[];
+  skipStage?: boolean;
   commitMessageFormat?: string;
   preset: PresetOpt | 'conventional'; // @TODO: Remove 'conventional' in the next major release.
   commitParserOptions?: CommitParserOptions;

--- a/packages/semver/src/executors/version/schema.json
+++ b/packages/semver/src/executors/version/schema.json
@@ -94,6 +94,11 @@
       "type": "boolean",
       "default": false
     },
+    "skipStage": {
+      "description": "Allows to skip adding files to git stage.",
+      "type": "boolean",
+      "default": false
+    },
     "skipCommitTypes": {
       "description": "Specify array of commit types to be ignored when calculating next version bump.",
       "type": "array",

--- a/packages/semver/src/executors/version/utils/git.spec.ts
+++ b/packages/semver/src/executors/version/utils/git.spec.ts
@@ -172,6 +172,7 @@ describe('git', () => {
         addToStage({
           paths: ['packages/demo/file.txt', 'packages/demo/other-file.ts'],
           dryRun: false,
+          skipStage: false,
         }),
       );
 
@@ -185,6 +186,21 @@ describe('git', () => {
       );
     });
 
+    it('should skip add to git stage if skipStage is true', async () => {
+      jest.spyOn(cp, 'exec').mockReturnValue(of('ok'));
+
+      await lastValueFrom(
+        addToStage({
+          paths: ['packages/demo/file.txt', 'packages/demo/other-file.ts'],
+          dryRun: false,
+          skipStage: true,
+        }),
+        { defaultValue: undefined },
+      );
+
+      expect(cp.exec).not.toBeCalled();
+    });
+
     it('should skip git add if paths argument is empty', async () => {
       jest.spyOn(cp, 'exec').mockReturnValue(of('ok'));
 
@@ -192,6 +208,7 @@ describe('git', () => {
         addToStage({
           paths: [],
           dryRun: false,
+          skipStage: false,
         }),
         { defaultValue: undefined },
       );

--- a/packages/semver/src/executors/version/utils/git.ts
+++ b/packages/semver/src/executors/version/utils/git.ts
@@ -128,11 +128,15 @@ export function tryPush({
 export function addToStage({
   paths,
   dryRun,
+  skipStage,
 }: {
   paths: string[];
   dryRun: boolean;
+  skipStage: boolean;
 }): Observable<void> {
   if (paths.length === 0) {
+    return EMPTY;
+  } else if (skipStage) {
     return EMPTY;
   }
 

--- a/packages/semver/src/executors/version/version.ts
+++ b/packages/semver/src/executors/version/version.ts
@@ -33,6 +33,7 @@ export interface CommonVersionOptions {
   tagPrefix: string;
   changelogHeader: string;
   skipCommit: boolean;
+  skipStage: boolean;
   commitMessage: string;
   projectName: string;
   skipProjectChangelog: boolean;
@@ -50,6 +51,7 @@ export function versionWorkspace({
   projectName,
   tag,
   skipCommit,
+  skipStage,
   projectRoot,
   ...options
 }: {
@@ -70,6 +72,7 @@ export function versionWorkspace({
       noVerify,
       projectName,
       skipCommit,
+      skipStage,
       tag,
       ...options,
     }),
@@ -90,6 +93,7 @@ export function versionWorkspace({
       addToStage({
         paths,
         dryRun,
+        skipStage,
       }),
     ),
     concatMap(() =>
@@ -124,6 +128,7 @@ export function versionProject({
   tagPrefix,
   projectName,
   skipCommit,
+  skipStage,
   tag,
   ...options
 }: {
@@ -138,6 +143,7 @@ export function versionProject({
     commitMessage,
     dryRun,
     skipCommit,
+    skipStage,
     noVerify,
     tagPrefix,
     tag,
@@ -153,7 +159,7 @@ export function versionProject({
             dependencyUpdates: options.dependencyUpdates,
           }).pipe(
             concatMap((changelogPath) =>
-              addToStage({ paths: [changelogPath], dryRun }),
+              addToStage({ paths: [changelogPath], dryRun, skipStage }),
             ),
           )
         : of(undefined),
@@ -170,6 +176,7 @@ export function versionProject({
             ? addToStage({
                 paths: [packageFile],
                 dryRun,
+                skipStage,
               })
             : of(undefined),
         ),


### PR DESCRIPTION
With this option I can run my 241 libraries in parallel - which greatly improves the time it takes to version the libs - when running nx affected targets=version --parallel 8

Without this change it is not possible to run in parallel at all, as add to stage requires a git-lock