### PR TITLE
fix: support continue chain so package.json will be updated

### DIFF
--- a/packages/semver/src/executors/version/utils/git.spec.ts
+++ b/packages/semver/src/executors/version/utils/git.spec.ts
@@ -201,6 +201,21 @@ describe('git', () => {
       expect(cp.exec).not.toBeCalled();
     });
 
+    it('should skip add to git stage if skipStage is true but should continue the chain', async () => {
+      jest.spyOn(cp, 'exec').mockReturnValue(of('ok'));
+
+      const value = await lastValueFrom(
+        addToStage({
+          paths: ['packages/demo/file.txt', 'packages/demo/other-file.ts'],
+          dryRun: false,
+          skipStage: true,
+        }),
+      );
+
+      expect(cp.exec).not.toBeCalled();
+      expect(value).toEqual(undefined);
+    });
+
     it('should skip git add if paths argument is empty', async () => {
       jest.spyOn(cp, 'exec').mockReturnValue(of('ok'));
 

--- a/packages/semver/src/executors/version/utils/git.ts
+++ b/packages/semver/src/executors/version/utils/git.ts
@@ -1,5 +1,5 @@
 import * as gitRawCommits from 'git-raw-commits';
-import { EMPTY, Observable, throwError } from 'rxjs';
+import { EMPTY, Observable, of, throwError } from 'rxjs';
 import { catchError, last, map, scan, startWith } from 'rxjs/operators';
 import { exec } from '../../common/exec';
 import { logStep, _logStep } from './logger';
@@ -137,7 +137,8 @@ export function addToStage({
   if (paths.length === 0) {
     return EMPTY;
   } else if (skipStage) {
-    return EMPTY;
+    // skip stage and return like this to ensure the chain will continue.
+    return of(undefined);
   }
 
   const gitAddOptions = [...(dryRun ? ['--dry-run'] : []), ...paths];


### PR DESCRIPTION
After adding addToStage skip support - I found that the chain is stopped and not continued - I managed to test it on my repo this time, and it works.