### PR TITLE
feat: add flag to enforce atomic push without a retry

### DIFF
--- a/packages/semver/src/executors/version/index.ts
+++ b/packages/semver/src/executors/version/index.ts
@@ -30,6 +30,7 @@ export default async function version(
 ): Promise<{ success: boolean }> {
   const {
     push,
+    enforceAtomicPush,
     remote,
     dryRun,
     trackDeps,
@@ -158,6 +159,7 @@ export default async function version(
           tag,
           branch: baseBranch,
           noVerify,
+          enforceAtomicPush,
           remote,
           projectName,
         }),
@@ -227,6 +229,7 @@ function _normalizeOptions(options: VersionBuilderSchema) {
   return {
     ...options,
     push: options.push as boolean,
+    enforceAtomicPush: options.enforceAtomicPush as boolean,
     remote: options.remote as string,
     dryRun: options.dryRun as boolean,
     trackDeps: options.trackDeps as boolean,

--- a/packages/semver/src/executors/version/schema.d.ts
+++ b/packages/semver/src/executors/version/schema.d.ts
@@ -19,6 +19,7 @@ export interface VersionBuilderSchema {
   dryRun?: boolean;
   noVerify?: boolean;
   push?: boolean;
+  enforceAtomicPush?: boolean;
   remote?: string;
   baseBranch?: string;
   syncVersions?: boolean;

--- a/packages/semver/src/executors/version/utils/git.ts
+++ b/packages/semver/src/executors/version/utils/git.ts
@@ -73,6 +73,7 @@ export function tryPush({
   remote,
   branch,
   noVerify,
+  enforceAtomicPush,
   projectName,
   tag,
 }: {
@@ -80,6 +81,7 @@ export function tryPush({
   remote: string;
   branch: string;
   noVerify: boolean;
+  enforceAtomicPush: boolean;
   projectName: string;
 }): Observable<string> {
   if (remote == null || branch == null) {
@@ -103,7 +105,7 @@ export function tryPush({
   ])
     .pipe(
       catchError((error) => {
-        if (/atomic/.test(error)) {
+        if (!enforceAtomicPush && /atomic/.test(error)) {
           _logStep({
             step: 'warning',
             level: 'warn',


### PR DESCRIPTION
### Draft PR

Add a flag to avoid retrying a non atomic push that could result in tags being pushed but not commits.
There is an open issue here: #801 

The current behavior is problematic for a lot of our repositories as we have a release process that is highly concurrent and result most of the time of orphan tags being pushed event with a failed CI. We would prefer to fail the CI without pushing orphan tags.

Documentation to be added.