### PR TITLE
feat: add support for Nx 21 in peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ For more details on using Nx Release, refer to the [official Nx documentation](h
 
 | Version | Required Package          |
 | ------- | ------------------------- |
+| v5.7.0  | `@nx/devkit ^21.0.0`      |
 | v5.5.0  | `@nx/devkit ^20.0.0`      |
 | v5.3.0  | `@nx/devkit ^19.0.0`      |
 | v5.0.0  | `@nx/devkit ^18.0.0`      |

--- a/packages/semver/package.json
+++ b/packages/semver/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/jscutlery/semver"
   },
   "peerDependencies": {
-    "@nx/devkit": "^18.0.0 || ^19.0.0 || ^20.0.0"
+    "@nx/devkit": "^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0"
   },
   "dependencies": {
     "chalk": "4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2102,7 +2102,7 @@ __metadata:
     inquirer: "npm:8.2.6"
     rxjs: "npm:7.8.2"
   peerDependencies:
-    "@nx/devkit": ^18.0.0 || ^19.0.0 || ^20.0.0
+    "@nx/devkit": ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Summary

This PR updates the `peerDependencies` of the `@nx/devkit` package to include support for Nx version 21 (`^21.0.0`). This is a follow-up to the previously added support for Nx 20 and ensures compatibility with the latest Nx releases.

### Motivation

While upgrading to Nx 21, I noticed that the `@nx/devkit` peer dependency was still limited to version 20. This PR mirrors the approach taken in [#915](https://github.com/jscutlery/semver/pull/915), where support for Nx 20 was added via an identical change to the peer dependency range.

### Notes

I followed the same approach as in the linked PR, but I was unsure how to verify that this change works correctly with Nx 21. I currently don't know the appropriate way to test whether the plugin still behaves as expected with the new version.

If there is a documented or recommended way to manually test compatibility with a new Nx major version, I'd be happy to follow it and ideally use that as a base to implement an automated workflow in the future.
