### PR TITLE
fix: prevent v10 failures by removing deprecated Husky hook initialization

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 yarn run commitlint --edit "$1"


### PR DESCRIPTION
### Summary

This PR removes the legacy initialization lines from `.husky/commit-msg` that relied on `husky.sh`.
These lines are deprecated as of Husky v9 and will cause failures in Husky v10 and above.

### Motivation

While running `git commit --amend`, the following deprecation warning appeared:

```
husky - DEPRECATED

Please remove the following two lines from .husky/commit-msg:
#!/usr/bin/env sh
. "$(dirname -- "$0")/_/husky.sh"

They WILL FAIL in v10.0.0
```

To comply with the migration guide and ensure compatibility with future versions of Husky, this PR updates the hook to rely solely on the direct `commitlint` invocation.
