### PR TITLE
feat: add @nx/devkit v22 peer dependency support

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ For more details on using Nx Release, refer to the [official Nx documentation](h
 
 | Version | Required Package          |
 | ------- | ------------------------- |
+| v5.8.0  | `@nx/devkit ^22.0.0`      |
 | v5.7.0  | `@nx/devkit ^21.0.0`      |
 | v5.5.0  | `@nx/devkit ^20.0.0`      |
 | v5.3.0  | `@nx/devkit ^19.0.0`      |

--- a/packages/semver/package.json
+++ b/packages/semver/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/jscutlery/semver"
   },
   "peerDependencies": {
-    "@nx/devkit": "^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0"
+    "@nx/devkit": "^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0 || ^22.0.0"
   },
   "dependencies": {
     "chalk": "4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2438,7 +2438,7 @@ __metadata:
     inquirer: "npm:8.2.7"
     rxjs: "npm:7.8.2"
   peerDependencies:
-    "@nx/devkit": ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0
+    "@nx/devkit": ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0 || ^22.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Summary

This PR updates the `peerDependencies` range for `@nx/devkit` to include support for Nx version 22 (`^22.0.0`). It follows the same approach as the previous update that added support for Nx 21. (#999)

### Motivation

While upgrading to Nx 22, I noticed that the `@nx/devkit` peer dependency range did not yet include version 22. This change ensures the plugin can be installed and used in Nx 22 workspaces without peer dependency warnings, mirroring the existing pattern used for prior Nx major bumps.

### Notes

The change is intentionally minimal and limited to the peer dependency range adjustment.

### References

Closes #1048
