### PR TITLE
ci: drop Node 21 (EOL) and add Node 22 + 24 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node_version: [20, 21]
+        node_version: [20, 22, 24]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Node 21 reached end-of-life in June 2024, so thought it made sense to clean that up.

At the same time, I added Node 22 (Active LTS) and Node 24 (Current) to make sure the package stays compatible with the versions people are actually running.

The matrix now covers:
- **20**
- **22**
- **24**