### PR TITLE
docs: add parallel=1 guidance for multi-project versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,8 +371,38 @@ then continuing up the graph until the indicated project is reached.
 Additionally, if used in conjunction with `nx run-many --all`, or `nx affected`,
 then it will avoid attempting to version dependencies multiple times.
 
-> [!WARNING]  
+> [!WARNING]
 > Be aware that this feature has known [limitations](https://github.com/jscutlery/semver/issues/526).
+
+### Running versioning on multiple projects
+
+When versioning multiple projects using `nx run-many` or `nx affected`, the version target must **not** run in parallel. Parallel execution causes concurrent git operations that conflict over the `.git/index.lock` file, resulting in errors like:
+
+```
+Another git process seems to be running in this repository
+```
+
+To fix this, set `--parallel=1` to ensure projects are versioned sequentially:
+
+```
+nx run-many --target=version --all --parallel=1
+nx affected --target=version --parallel=1
+```
+
+Alternatively, you can set this in `nx.json` so it applies automatically:
+
+```json
+{
+  "targetDefaults": {
+    "version": {
+      "parallelism": false
+    }
+  }
+}
+```
+
+> [!NOTE]
+> This limitation exists because the version target performs git operations (commits, tags, pushes) that require exclusive access to the repository's `.git/index.lock` file.
 
 ## CI/CD usage
 
@@ -404,7 +434,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Version
         shell: bash
-        run: pnpm nx affected --base=last-release --target=version
+        run: pnpm nx affected --base=last-release --target=version --parallel=1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Tag last-release
@@ -436,7 +466,7 @@ release:
     - git remote set-url origin http://gitlab-ci-token:${DEPLOY_KEY}@gitlab.com/org/project.git
   script:
     - pnpm install --frozen-lockfile
-    - pnpm nx affected --target=version --base=last-release
+    - pnpm nx affected --target=version --base=last-release --parallel=1
     - git tag -f last-release
     - git push origin last-release --force -o ci.skip
 ```


### PR DESCRIPTION
## Summary

- Add a new "Running versioning on multiple projects" section to the README documenting the need to use `--parallel=1` when running `nx run-many` or `nx affected` with the `version` target, to prevent `.git/index.lock` conflicts
- Include both CLI flag (`--parallel=1`) and `nx.json` configuration (`parallelism: false`) approaches
- Update GitHub Actions and GitLab CI examples to include `--parallel=1`

Closes #500

## Context

When versioning multiple projects in parallel, concurrent git operations (commits, tags, pushes) conflict over the `.git/index.lock` file, causing `"Another git process seems to be running in this repository"` errors. This was reported in #414 and the solution (`--parallel=1`) was found in the comments, but it was never documented. Issue #500 specifically requested adding this to the docs.

## Test plan

- [ ] Verify the README renders correctly on GitHub (section headings, code blocks, admonitions)
- [ ] Confirm the `nx.json` configuration example uses the correct property name for the Nx version targeted by the project

🤖 Generated with [Claude Code](https://claude.com/claude-code)