### PR TITLE
fix(semver): preserve named preset overrides in changelog generation

### DIFF
--- a/packages/semver/src/executors/version/utils/conventional-commit.spec.ts
+++ b/packages/semver/src/executors/version/utils/conventional-commit.spec.ts
@@ -1,0 +1,61 @@
+import * as conventionalChangelog from 'conventional-changelog';
+import { createConventionalCommitStream } from './conventional-commit';
+import type { WriteChangelogConfig } from '../schema';
+
+jest.mock('conventional-changelog', () => jest.fn());
+
+const config: WriteChangelogConfig = {
+  changelogHeader: '# Changelog',
+  projectRoot: './libs/demo',
+  preset: 'conventionalcommits',
+  dryRun: false,
+  changelogPath: 'CHANGELOG.md',
+  tagPrefix: 'demo-',
+};
+
+describe(createConventionalCommitStream.name, () => {
+  const conventionalChangelogMock =
+    conventionalChangelog as jest.MockedFunction<typeof conventionalChangelog>;
+
+  beforeEach(() => {
+    conventionalChangelogMock.mockReset();
+  });
+
+  it('should pass named preset objects as preset and config', () => {
+    const preset = {
+      name: 'conventional-changelog-conventionalcommits-jira',
+      issuePrefixes: ['YEUPSD', 'TANK'],
+      issueUrlFormat:
+        'https://yaradigitalfarming.atlassian.net/browse/{{prefix}}{{id}}',
+    };
+
+    createConventionalCommitStream({ ...config, preset }, '1.0.0');
+
+    expect(conventionalChangelogMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preset: 'conventional-changelog-conventionalcommits-jira',
+        config: preset,
+      }),
+      { version: '1.0.0' },
+      { path: './libs/demo' },
+      undefined,
+    );
+  });
+
+  it('should default unnamed preset objects to conventionalcommits', () => {
+    const preset = {
+      types: [{ type: 'feat', section: 'Awesome Features' }],
+    };
+
+    createConventionalCommitStream({ ...config, preset }, '1.0.0');
+
+    expect(conventionalChangelogMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: preset,
+      }),
+      { version: '1.0.0' },
+      { path: './libs/demo' },
+      undefined,
+    );
+  });
+});

--- a/packages/semver/src/executors/version/utils/conventional-commit.ts
+++ b/packages/semver/src/executors/version/utils/conventional-commit.ts
@@ -9,8 +9,7 @@ export function createConventionalCommitStream(
 ) {
   return conventionalChangelog(
     {
-      ...(typeof config.preset === 'string' ? { preset: config.preset } : {}),
-      ...(typeof config.preset === 'object' ? { config: config.preset } : {}),
+      ...resolvePresetOptions(config),
       tagPrefix: config.tagPrefix,
       pkg: {
         path: path.join(config.projectRoot, 'package.json'),
@@ -21,4 +20,19 @@ export function createConventionalCommitStream(
     { path: config.projectRoot },
     config.commitParserOptions,
   );
+}
+
+function resolvePresetOptions(config: WriteChangelogConfig) {
+  if (typeof config.preset === 'string') {
+    return { preset: config.preset };
+  }
+
+  if (!config.preset.name) {
+    return { config: config.preset };
+  }
+
+  return {
+    preset: config.preset.name ?? 'conventionalcommits',
+    config: config.preset,
+  };
 }

--- a/packages/semver/src/executors/version/utils/write-changelog.spec.ts
+++ b/packages/semver/src/executors/version/utils/write-changelog.spec.ts
@@ -1,11 +1,13 @@
 import * as fs from 'fs';
 import * as Stream from 'stream';
+import * as createPreset from 'conventional-changelog-conventionalcommits';
 
 import writeChangelog from './write-changelog';
 import type { WriteChangelogConfig } from '../schema';
 import { createConventionalCommitStream } from './conventional-commit';
 
 jest.mock('./conventional-commit');
+jest.mock('conventional-changelog-conventionalcommits');
 
 /**
  * @todo: This test is disabled because it is not working in the CI environment.
@@ -25,15 +27,85 @@ describe(writeChangelog, () => {
     createConventionalCommitStream as jest.MockedFunction<
       typeof createConventionalCommitStream
     >;
+  const createPresetMock = createPreset as jest.MockedFunction<
+    typeof createPreset
+  >;
+  const version = '1.0.0';
 
   beforeEach(() => {
     jest.spyOn(console, 'warn').mockImplementation(() => jest.fn());
     jest.spyOn(console, 'info').mockImplementation(() => jest.fn());
     jest.spyOn(fs, 'writeFileSync').mockImplementation(() => jest.fn());
+    createPresetMock.mockReset();
   });
 
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('preset forwarding', () => {
+    beforeEach(() => {
+      createConventionalCommitStreamMock.mockReturnValue(createMockStream());
+    });
+
+    it('preserves named preset objects with sibling overrides', async () => {
+      const preset = {
+        name: 'conventional-changelog-conventionalcommits-jira',
+        issuePrefixes: ['YEUPSD', 'TANK'],
+        issueUrlFormat:
+          'https://yaradigitalfarming.atlassian.net/browse/{{prefix}}{{id}}',
+      };
+
+      await writeChangelog(
+        {
+          ...config,
+          preset,
+          dryRun: true,
+        },
+        version,
+      );
+
+      expect(createConventionalCommitStreamMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          preset,
+        }),
+        version,
+      );
+      expect(createPresetMock).not.toHaveBeenCalled();
+    });
+
+    it('resolves unnamed object presets before creating the stream', async () => {
+      const preset = {
+        types: [
+          { type: 'feat', section: 'Awesome Features' },
+          { type: 'fix', section: 'Important Fixes' },
+        ],
+      };
+      const resolvedPreset = {
+        commits: {},
+        parser: {},
+        writer: {},
+        whatBump: jest.fn(),
+      };
+      createPresetMock.mockResolvedValue(resolvedPreset);
+
+      await writeChangelog(
+        {
+          ...config,
+          preset,
+          dryRun: true,
+        },
+        version,
+      );
+
+      expect(createPresetMock).toHaveBeenCalledWith(preset);
+      expect(createConventionalCommitStreamMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          preset: resolvedPreset,
+        }),
+        version,
+      );
+    });
   });
 
   xdescribe('handle errors', () => {
@@ -130,3 +202,14 @@ describe(writeChangelog, () => {
     });
   });
 });
+
+function createMockStream() {
+  const stream = new Stream.Readable({
+    read() {
+      this.push('## 1.0.0');
+      this.push(null);
+    },
+  });
+
+  return stream;
+}

--- a/packages/semver/src/executors/version/utils/write-changelog.ts
+++ b/packages/semver/src/executors/version/utils/write-changelog.ts
@@ -61,7 +61,7 @@ async function buildConventionalChangelog(
   newVersion: string,
 ): Promise<string> {
   const preset =
-    typeof config.preset === 'object'
+    typeof config.preset === 'object' && !config.preset.name
       ? await createPreset(config.preset)
       : config.preset;
 


### PR DESCRIPTION
## Summary
- preserve `preset` objects with both `name` and sibling overrides during changelog generation
- align `conventional-changelog` preset handling with the existing `conventional-recommended-bump` behavior
- add regression tests for named preset objects and unnamed preset override objects

## Why
`@jscutlery/semver` documents `preset` as supporting both strings and objects, including named preset objects such as:

```json
{
  "preset": {
    "name": "angular",
    "types": [
      { "type": "feat", "section": "✨ Features" },
      { "type": "fix", "section": "🐞 Bug Fixes" }
    ]
  }
}
```

In practice, changelog generation flattened named preset objects into a plain string. That allowed the preset package to be selected, but it dropped sibling overrides like `issuePrefixes`, `issueUrlFormat`, or custom `types`.

This broke valid documented configurations and custom preset setups such as Jira-style changelog presets.

Closes #794.

## Test plan
- [x] Run `pnpm exec jest packages/semver/src/executors/version/utils/write-changelog.spec.ts packages/semver/src/executors/version/utils/conventional-commit.spec.ts packages/semver/src/executors/version/utils/try-bump.spec.ts --runInBand`