### PR TITLE
fix(semver): declare git-raw-commits as direct dependency

### DIFF
--- a/packages/semver/package.json
+++ b/packages/semver/package.json
@@ -31,6 +31,7 @@
     "conventional-recommended-bump": "^9.0.0",
     "detect-indent": "6.1.0",
     "semver": "^7.0.0",
+    "git-raw-commits": "^4.0.0",
     "git-semver-tags": "^7.0.1",
     "inquirer": "8.2.7",
     "rxjs": "7.8.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
       detect-indent:
         specifier: 6.1.0
         version: 6.1.0
+      git-raw-commits:
+        specifier: ^4.0.0
+        version: 4.0.0
       git-semver-tags:
         specifier: ^7.0.1
         version: 7.0.1


### PR DESCRIPTION
## Problem

The version executor calls `require('git-raw-commits')` in `packages/semver/src/executors/version/utils/git.ts` and invokes the return value as a function:

```ts
const gitRawCommits = require('git-raw-commits');
// ...
gitRawCommits(params)
  .on('data', (data) => observer.next(data))
```

But `git-raw-commits` is not listed in `dependencies`. It has been resolved transitively via hoisting from sibling packages (e.g. older `conventional-changelog` chains that pull in v4).

## Symptom

Consumers installing `@jscutlery/semver@^6` in a workspace that also pulls in `git-raw-commits >= 5` (commonly via `@commitlint/read@20`, which now depends on `git-raw-commits@^5`) get the ESM-only v5 hoisted instead. v5 changed its export shape from a default callable to named exports:

```js
// v4
module.exports = function gitRawCommits(opts) { /* returns stream */ }

// v5
export { getRawCommits, getRawCommitsStream }
```

`require('git-raw-commits')` then returns an object, and the call site throws at runtime:

```
TypeError: gitRawCommits is not a function
    at getFormattedCommits (.../executors/version/utils/git.js:46:9)
```

Every `nx run <project>:version` invocation fails — releases are blocked workspace-wide. I have hit this in multiple repos now.

## Fix

Declare `git-raw-commits` as a direct dependency pinned to the v4 major the executor is written against. This makes resolution deterministic and decouples us from whatever sibling tooling the consumer has installed.

Migrating the executor to the v5 API (`getRawCommits` + async iterator) is a separate, larger change — this PR is the minimal fix to unblock consumers on existing v6.

## Verification

- `pnpm exec nx run semver:test` — 194 passed (0 regressions)
- `pnpm exec nx run semver:e2e` — 56 passed
- Reproduced the failure locally by temporarily bumping to `^5.0.0`: 50/56 e2e fail with `TypeError: gitRawCommits is not a function` — the exact error reported by downstream consumers. Reverting to `^4.0.0` restores green.
