### PR TITLE
docs: remove non-existent --skipTag flag from Skipping Stage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ The tag for the new version would be put on the last existing commit.
 
 ### Skipping Stage
 
-In case you want to run nx cmd in parallel, you can provide the `--skipStage` flag and it will not add to git stage - since that requires a git-lock, this has to be used together with `--skipCommit` and `--skipTag` and not with `--push`, all for the same reason they will require a git-lock.
+In case you want to run nx cmd in parallel, you can provide the `--skipStage` flag and it will not add to git stage - since that requires a git-lock, this has to be used together with `--skipCommit` and not with `--push`, all for the same reason they will require a git-lock.
 
 ### Triggering executors post-release
 


### PR DESCRIPTION
## Problem

The [Skipping Stage](https://github.com/jscutlery/semver?tab=readme-ov-file#skipping-stage) section of the README documents `--skipTag` as a required companion to `--skipStage`:

> ... this has to be used together with `--skipCommit` and `--skipTag` and not with `--push` ...

But `--skipTag` does not exist. It is not declared in `packages/semver/src/executors/version/schema.json`, `schema.d.ts`, or any executor code path — `grep -rn skipTag .` returns `README.md` as the only hit in the entire repo.

Git history shows the flag was mentioned in commit `d97abf04` ("feat: added option to skip stage") alongside the `--skipStage` implementation, but only `--skipStage` itself ever landed.

## Fix

Drop the `--skipTag` reference from the paragraph. Single-line diff, no other changes:

```diff
-this has to be used together with `--skipCommit` and `--skipTag` and not with `--push`
+this has to be used together with `--skipCommit` and not with `--push`
```

## Verification

- `grep -rn skipTag .` returns no matches after the change.
- No code paths touched; `nx affected -t lint,test,build` is effectively a no-op.

Closes #1076
