### PR TITLE
fix(semver): blank-line separator after Dependency Updates section

### DIFF
--- a/packages/semver/src/executors/version/__snapshots__/index.e2e.spec.ts.snap
+++ b/packages/semver/src/executors/version/__snapshots__/index.e2e.spec.ts.snap
@@ -29,6 +29,24 @@ exports[`@jscutlery/semver @jscutlery/semver:migrate-nx-release should generate 
 "
 `;
 
+exports[`@jscutlery/semver @jscutlery/semver:version trackDeps cascade should generate libs/parent/CHANGELOG.md with dep-only chain: trackDeps cascade > libs/parent/CHANGELOG.md dep-only chain (parent 0.0.1 → 0.0.2) 1`] = `
+"# Changelog
+
+This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
+
+## [0.0.2](///compare/parent-0.0.1...parent-0.0.2) (yyyy-mm-dd)
+
+### Dependency Updates
+
+* \`child\` updated to version \`0.2.0\`
+## 0.0.1 (yyyy-mm-dd)
+
+### Dependency Updates
+
+* \`child\` updated to version \`0.1.0\`
+"
+`;
+
 exports[`@jscutlery/semver @jscutlery/semver:version when graduating prerelease to stable release (v1.2.0-alpha.0 => v1.2.0) should generate CHANGELOG.md: a-1.2.0 1`] = `
 "# Changelog
 

--- a/packages/semver/src/executors/version/__snapshots__/index.e2e.spec.ts.snap
+++ b/packages/semver/src/executors/version/__snapshots__/index.e2e.spec.ts.snap
@@ -39,6 +39,7 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 ### Dependency Updates
 
 * \`child\` updated to version \`0.2.0\`
+
 ## 0.0.1 (yyyy-mm-dd)
 
 ### Dependency Updates

--- a/packages/semver/src/executors/version/index.e2e.spec.ts
+++ b/packages/semver/src/executors/version/index.e2e.spec.ts
@@ -524,6 +524,83 @@ describe('@jscutlery/semver', () => {
         ).toMatchSnapshot('b-0.2.0');
       });
     });
+
+    describe('trackDeps cascade', () => {
+      beforeAll(() => {
+        testingWorkspace.generateLib(
+          'child',
+          '--publishable --importPath=@proj/child',
+        );
+        testingWorkspace.installSemver('child', '--preset=conventionalcommits');
+        testingWorkspace.generateLib(
+          'parent',
+          '--publishable --importPath=@proj/parent',
+        );
+        testingWorkspace.installSemver(
+          'parent',
+          '--preset=conventionalcommits',
+        );
+
+        const parentProjectPath = `${testingWorkspace.root}/libs/parent/project.json`;
+        const parentProject = JSON.parse(
+          readFileSync(parentProjectPath, 'utf-8'),
+        );
+        parentProject.targets.version.options.trackDeps = true;
+        parentProject.implicitDependencies = ['child'];
+        writeFileSync(
+          parentProjectPath,
+          JSON.stringify(parentProject, null, 2),
+        );
+
+        testingWorkspace.exec(
+          `
+              git add .
+              git commit -m "chore: 🐣 set up trackDeps cascade libs" --no-verify
+          `,
+        );
+
+        testingWorkspace.exec(
+          `
+              echo feat > libs/child/child.txt
+              git add .
+              git commit -m "feat(child): 🚀 new feature 1"
+          `,
+        );
+        testingWorkspace.runNx(`run child:version --noVerify`);
+        testingWorkspace.runNx(`run parent:version --noVerify`);
+
+        testingWorkspace.exec(
+          `
+              echo feat >> libs/child/child.txt
+              git add .
+              git commit -m "feat(child): 🚀 new feature 2"
+          `,
+        );
+        testingWorkspace.runNx(`run child:version --noVerify`);
+        testingWorkspace.runNx(`run parent:version --noVerify`);
+      });
+
+      it('should tag child and parent through both cascades', () => {
+        expect(getTags(testingWorkspace.root)).toEqual(
+          expect.arrayContaining([
+            'child-0.1.0',
+            'child-0.2.0',
+            'parent-0.0.1',
+            'parent-0.0.2',
+          ]),
+        );
+      });
+
+      it('should generate libs/parent/CHANGELOG.md with dep-only chain', () => {
+        expect(
+          deterministicChangelog(
+            readFile(`${testingWorkspace.root}/libs/parent/CHANGELOG.md`),
+          ),
+        ).toMatchSnapshot(
+          'trackDeps cascade > libs/parent/CHANGELOG.md dep-only chain (parent 0.0.1 → 0.0.2)',
+        );
+      });
+    });
   });
 
   describe('@jscutlery/semver:migrate-nx-release', () => {

--- a/packages/semver/src/executors/version/utils/changelog.ts
+++ b/packages/semver/src/executors/version/utils/changelog.ts
@@ -139,10 +139,13 @@ export function _calculateDependencyUpdates({
       return acc;
     }, [] as string[]);
 
+    const headerEnd = match.index + match[0].length;
+    const rest = changelog.substring(headerEnd).replace(/^\n+/, '');
+
     changelog =
-      `${changelog.substring(0, match.index + match[0].length)}` +
-      `\n\n### Dependency Updates\n\n${dependencyNames.join('\n')}\n` +
-      `${changelog.substring(match.index + match[0].length + 2)}`;
+      `${changelog.substring(0, headerEnd)}` +
+      `\n\n### Dependency Updates\n\n${dependencyNames.join('\n')}\n\n` +
+      rest;
   }
 
   return changelog;


### PR DESCRIPTION
## Problem

In a workspace using `trackDeps: true`, a lib that gets cascading dep-only bumps (no own commits, just `### Dependency Updates` entries) produces a malformed CHANGELOG where consecutive version headings run into each other with no blank line between them:

```
## [4.0.6](...) (2026-04-09)

### Dependency Updates

* `shared-lib` updated to version `8.0.1`
## [4.0.5](...) (2026-04-09)          <-- bug: no blank line above
```

Expected:

```
* `shared-lib` updated to version `8.0.1`

## [4.0.5](...) (2026-04-09)
```

## Root cause

`_calculateDependencyUpdates` in `packages/semver/src/executors/version/utils/changelog.ts`:

```ts
`\n\n### Dependency Updates\n\n${dependencyNames.join('\n')}\n` +   // ends with ONE \n
`${changelog.substring(match.index + match[0].length + 2)}`;       // strips \n\n after heading
```

The injected block ends with a single `\n` and the `+2` offset strips the `\n\n` that originally followed the heading. When the "rest" starts with another version heading (i.e. the current version has ONLY dep updates, no other subsections), the joined result is `<deps>\n## [prev]` — one newline, no blank line.

The bug is silent when the current version also has `### Features` / `### Bug Fixes` / etc., because conventional-changelog emits `\n\n\n` after headings with content, and the `+2` strip leaves one `\n` leftover that accidentally restores the blank line.

## Fix

- End the injected block with `\n\n` (guaranteeing a blank line after the dep list).
- Strip all leading `\n`s from the "rest" via `/^\n+/` instead of the brittle fixed `+2` offset — avoids over-padding when conventional-changelog already wrote `\n\n\n` after the heading.

## Verification

New e2e scenario in `index.e2e.spec.ts`: two consecutive dep-only cascades on a `parent` lib with `trackDeps: true` and an `implicitDependencies: ['child']` edge. Split into two commits for easy review:

- **f4c23934 `test(semver): ...`** — adds the scenario and captures the **buggy** layout in the snapshot: `* child updated to version 0.2.0` is directly followed by `## 0.0.1` with no blank line.
- **6eec6232 `fix(semver): ...`** — applies the fix. The snapshot diff on this commit is a single `+` line — exactly the missing blank line.

Test runs:

- `pnpm exec nx run semver:e2e` — 58 passed, 12 snapshots.
- `pnpm exec nx run semver:test` — 194 passed, no regressions.
