### PR TITLE
fix(semver): collapse blank lines between changelog sections

### DIFF
--- a/packages/semver/src/executors/version/__snapshots__/index.e2e.spec.ts.snap
+++ b/packages/semver/src/executors/version/__snapshots__/index.e2e.spec.ts.snap
@@ -55,13 +55,11 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [1.2.0](///compare/a-1.2.0-alpha.0...a-1.2.0) (yyyy-mm-dd)
 
-
 ### Bug Fixes
 
 * **a:** 🐞 final fix before release xxxxxxx
 
 ## [1.2.0-alpha.0](///compare/a-1.1.0-alpha.0...a-1.2.0-alpha.0) (yyyy-mm-dd)
-
 
 ### Features
 
@@ -69,13 +67,11 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [1.1.0-alpha.0](///compare/a-1.1.0-beta.1...a-1.1.0-alpha.0) (yyyy-mm-dd)
 
-
 ### Features
 
 * **a:** 🚀 new feature 1 xxxxxxx
 
 ## [1.1.0-beta.1](///compare/a-1.1.0-beta.0...a-1.1.0-beta.1) (yyyy-mm-dd)
-
 
 ### Features
 
@@ -83,13 +79,11 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [1.1.0-beta.0](///compare/a-1.0.0...a-1.1.0-beta.0) (yyyy-mm-dd)
 
-
 ### Features
 
 * **a:** 🚀 new feature 1 xxxxxxx
 
 ## [1.0.0](///compare/a-0.1.1...a-1.0.0) (yyyy-mm-dd)
-
 
 ### ⚠ BREAKING CHANGES
 
@@ -101,18 +95,15 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [0.1.1](///compare/a-0.1.0...a-0.1.1) (yyyy-mm-dd)
 
-
 ### Bug Fixes
 
 * **a:** 🐞 fix bug xxxxxxx
 
 ## 0.1.0 (yyyy-mm-dd)
 
-
 ### Features
 
 * **a:** 🚀 new feature xxxxxxx
-
 
 ### Bug Fixes
 
@@ -127,11 +118,9 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## 0.1.0 (yyyy-mm-dd)
 
-
 ### Features
 
 * **a:** 🚀 new feature xxxxxxx
-
 
 ### Bug Fixes
 
@@ -146,18 +135,15 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [0.1.1](///compare/a-0.1.0...a-0.1.1) (yyyy-mm-dd)
 
-
 ### Bug Fixes
 
 * **a:** 🐞 fix bug xxxxxxx
 
 ## 0.1.0 (yyyy-mm-dd)
 
-
 ### Features
 
 * **a:** 🚀 new feature xxxxxxx
-
 
 ### Bug Fixes
 
@@ -172,7 +158,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [1.0.0](///compare/a-0.1.1...a-1.0.0) (yyyy-mm-dd)
 
-
 ### ⚠ BREAKING CHANGES
 
 * **a:** 🚨 Breaking change description
@@ -183,18 +168,15 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [0.1.1](///compare/a-0.1.0...a-0.1.1) (yyyy-mm-dd)
 
-
 ### Bug Fixes
 
 * **a:** 🐞 fix bug xxxxxxx
 
 ## 0.1.0 (yyyy-mm-dd)
 
-
 ### Features
 
 * **a:** 🚀 new feature xxxxxxx
-
 
 ### Bug Fixes
 
@@ -209,11 +191,9 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## 0.1.0 (yyyy-mm-dd)
 
-
 ### Features
 
 * **b:** 🚀 new feature xxxxxxx
-
 
 ### Bug Fixes
 
@@ -228,18 +208,15 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [0.2.0](///compare/b-0.1.0...b-0.2.0) (yyyy-mm-dd)
 
-
 ### Features
 
 * **b:** 🚀 new feature xxxxxxx
 
 ## 0.1.0 (yyyy-mm-dd)
 
-
 ### Features
 
 * **b:** 🚀 new feature xxxxxxx
-
 
 ### Bug Fixes
 
@@ -254,7 +231,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## 0.1.0 (yyyy-mm-dd)
 
-
 ### ✨ Awesome features
 
 * **d:** 🚀 new awesome feature xxxxxxx
@@ -268,13 +244,11 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [1.2.0-alpha.0](///compare/a-1.1.0-alpha.0...a-1.2.0-alpha.0) (yyyy-mm-dd)
 
-
 ### Features
 
 * **a:** 🚀 new feature 2 xxxxxxx
 
 ## [1.1.0-alpha.0](///compare/a-1.1.0-beta.1...a-1.1.0-alpha.0) (yyyy-mm-dd)
-
 
 ### Features
 
@@ -282,20 +256,17 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [1.1.0-beta.1](///compare/a-1.1.0-beta.0...a-1.1.0-beta.1) (yyyy-mm-dd)
 
-
 ### Features
 
 * **a:** 🚀 new feature 2 xxxxxxx
 
 ## [1.1.0-beta.0](///compare/a-1.0.0...a-1.1.0-beta.0) (yyyy-mm-dd)
 
-
 ### Features
 
 * **a:** 🚀 new feature 1 xxxxxxx
 
 ## [1.0.0](///compare/a-0.1.1...a-1.0.0) (yyyy-mm-dd)
-
 
 ### ⚠ BREAKING CHANGES
 
@@ -307,18 +278,15 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [0.1.1](///compare/a-0.1.0...a-0.1.1) (yyyy-mm-dd)
 
-
 ### Bug Fixes
 
 * **a:** 🐞 fix bug xxxxxxx
 
 ## 0.1.0 (yyyy-mm-dd)
 
-
 ### Features
 
 * **a:** 🚀 new feature xxxxxxx
-
 
 ### Bug Fixes
 
@@ -333,20 +301,17 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [1.1.0-beta.1](///compare/a-1.1.0-beta.0...a-1.1.0-beta.1) (yyyy-mm-dd)
 
-
 ### Features
 
 * **a:** 🚀 new feature 2 xxxxxxx
 
 ## [1.1.0-beta.0](///compare/a-1.0.0...a-1.1.0-beta.0) (yyyy-mm-dd)
 
-
 ### Features
 
 * **a:** 🚀 new feature 1 xxxxxxx
 
 ## [1.0.0](///compare/a-0.1.1...a-1.0.0) (yyyy-mm-dd)
-
 
 ### ⚠ BREAKING CHANGES
 
@@ -358,18 +323,15 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [0.1.1](///compare/a-0.1.0...a-0.1.1) (yyyy-mm-dd)
 
-
 ### Bug Fixes
 
 * **a:** 🐞 fix bug xxxxxxx
 
 ## 0.1.0 (yyyy-mm-dd)
 
-
 ### Features
 
 * **a:** 🚀 new feature xxxxxxx
-
 
 ### Bug Fixes
 
@@ -384,13 +346,11 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [0.2.0](///compare/d-0.1.0...d-0.2.0) (yyyy-mm-dd)
 
-
 ### ✨ Awesome features
 
 * **d:** 🚀 new feature xxxxxxx
 
 ## 0.1.0 (yyyy-mm-dd)
-
 
 ### ✨ Awesome features
 

--- a/packages/semver/src/executors/version/utils/__snapshots__/write-changelog.spec.ts.snap
+++ b/packages/semver/src/executors/version/utils/__snapshots__/write-changelog.spec.ts.snap
@@ -3,11 +3,9 @@
 exports[`writeChangelog changelog section spacing writes the generated changelog block: write-changelog: blank lines between version header and sections 1`] = `
 "## 1.0.0 (2024-01-01)
 
-
 ### Features
 
 * **button:** add a button
-
 
 ### Bug Fixes
 

--- a/packages/semver/src/executors/version/utils/__snapshots__/write-changelog.spec.ts.snap
+++ b/packages/semver/src/executors/version/utils/__snapshots__/write-changelog.spec.ts.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`writeChangelog changelog section spacing writes the generated changelog block: write-changelog: blank lines between version header and sections 1`] = `
+"## 1.0.0 (2024-01-01)
+
+
+### Features
+
+* **button:** add a button
+
+
+### Bug Fixes
+
+* **button:** fix the click handler
+"
+`;

--- a/packages/semver/src/executors/version/utils/write-changelog.spec.ts
+++ b/packages/semver/src/executors/version/utils/write-changelog.spec.ts
@@ -108,6 +108,36 @@ describe(writeChangelog, () => {
     });
   });
 
+  describe('changelog section spacing', () => {
+    beforeEach(() => {
+      jest.spyOn(fs, 'accessSync').mockReturnValue(undefined);
+      jest.spyOn(fs, 'readFileSync').mockReturnValue('');
+    });
+
+    it('writes the generated changelog block', async () => {
+      const rawConventionalCommitsBlock =
+        '## 1.0.0 (2024-01-01)\n' +
+        '\n\n' +
+        '### Features\n\n* **button:** add a button\n' +
+        '\n\n' +
+        '### Bug Fixes\n\n* **button:** fix the click handler\n';
+      createConventionalCommitStreamMock.mockReturnValue(
+        streamOf(rawConventionalCommitsBlock),
+      );
+
+      await writeChangelog(config, version);
+
+      const written = (fs.writeFileSync as jest.Mock).mock
+        .calls[0][1] as string;
+      const generatedBlock = written.slice(
+        `${config.changelogHeader}\n`.length,
+      );
+      expect(generatedBlock).toMatchSnapshot(
+        'write-changelog: blank lines between version header and sections',
+      );
+    });
+  });
+
   xdescribe('handle errors', () => {
     beforeEach(async () => {
       createConventionalCommitStreamMock.mockReturnValue(
@@ -212,4 +242,13 @@ function createMockStream() {
   });
 
   return stream;
+}
+
+function streamOf(content: string) {
+  return new Stream.Readable({
+    read() {
+      this.push(content);
+      this.push(null);
+    },
+  });
 }

--- a/packages/semver/src/executors/version/utils/write-changelog.ts
+++ b/packages/semver/src/executors/version/utils/write-changelog.ts
@@ -13,7 +13,15 @@ export default function writeChangelog(
   newVersion: string,
 ): Promise<void> {
   return buildConventionalChangelog(config, newVersion)
-    .then((newContent) => {
+    .then((generatedContent) => {
+      /**
+       * conventional-changelog-conventionalcommits emits two blank lines after
+       * the version header and between sections. Collapse runs of blank lines
+       * in the freshly generated block down to a single blank line. Only the
+       * new content is normalized so previously written entries stay untouched.
+       */
+      const newContent = generatedContent.replace(/\n{3,}/g, '\n\n');
+
       if (config.dryRun) {
         return console.info(`\n---\n${chalk.gray(newContent.trim())}\n---\n`);
       }


### PR DESCRIPTION
## What

`@jscutlery/semver` renders changelogs through
`conventional-changelog-conventionalcommits`, which emits two blank lines after
the version header and between sections. This collapses runs of blank lines in
the freshly generated block down to a single blank line.

Only the newly generated block is normalized. Previously written entries are
left untouched.

## Why

Multiple consecutive blank lines are redundant (CommonMark renders one and two
identically). This is what Prettier's markdown formatter collapses, and it is the
case flagged by markdownlint's `MD012` (no-multiple-blanks). The generated
changelog now satisfies that single-blank-line convention out of the box, instead
of relying on the changelog being excluded from formatting.

Scope: this addresses the blank-line spacing only. It does not try to make the
changelog fully Prettier-clean (Prettier would also rewrite `*` list markers to
`-`, etc.). It removes this one specific formatting issue.

It also lines up with the existing post-processing in
`_calculateDependencyUpdates`, which already normalizes spacing around the
Dependency Updates section.

## Two commits for an easy review

The change is intentionally split into two commits so the behavioral difference
is explicit and verifiable:

1. `test(semver): cover changelog section spacing` adds a test and a snapshot
   that capture the current output, including the two blank lines produced by
   conventional-changelog. It passes against the unchanged implementation.
2. `fix(semver): collapse blank lines between changelog sections` applies the fix
   and, in the same commit, adjusts that snapshot (and the e2e snapshots). The
   snapshot diff shows exactly which blank line is removed, right next to the
   implementation change, so the behavioral change is visible at a glance. This
   spans feature, fix, breaking-change and custom-preset releases.
