### PR TITLE
ci(semver): give the nx auto-update PR a conventional commit title

### DIFF
--- a/.github/workflows/nx-migrate.yml
+++ b/.github/workflows/nx-migrate.yml
@@ -10,6 +10,12 @@ jobs:
   nx-migrate:
     runs-on: ubuntu-latest
 
+    env:
+      # Conventional Commit subject (minus the version) reused by the bot commit
+      # and the PR title so the squash-merged commit stays a valid Conventional
+      # Commit. Single source of truth: edit here, both call sites follow.
+      NX_UPDATE_TITLE_PREFIX: 'build: 📦 update @nx/workspace to'
+
     steps:
       - uses: actions/checkout@v6
       - name: Setup
@@ -56,7 +62,7 @@ jobs:
         run: |
           LAST_VERSION=$(npm view @nx/workspace version)
           git add .
-          [[ $(git status --porcelain) ]] && git commit -m "build: 📦 update nrwl workspace to ${LAST_VERSION}" || echo "nothing to commit"
+          [[ $(git status --porcelain) ]] && git commit -m "${NX_UPDATE_TITLE_PREFIX} ${LAST_VERSION}" || echo "nothing to commit"
 
       - name: Remove migrations.json & commit
         if: steps.nrwl-workspace-has-migrations.outputs.has_migrations == 'true'
@@ -81,7 +87,7 @@ jobs:
           BRANCH="update-nrwl-workspace-${LAST_VERSION}"
           git checkout -b ${BRANCH}
           git push -f --set-upstream origin ${BRANCH}
-          gh pr view ${BRANCH} || gh pr create -t "Update @nx/workspace to ${BRANCH}" -b "Update @nx/workspace dependencies to ${LAST_VERSION}."
+          gh pr view ${BRANCH} || gh pr create -t "${NX_UPDATE_TITLE_PREFIX} ${LAST_VERSION}" -b "Update @nx/workspace dependencies to ${LAST_VERSION}."
         env:
           GITHUB_TOKEN: ${{ secrets.GIT_BOT_TOKEN }}
 
@@ -90,8 +96,10 @@ jobs:
         run: |
           LAST_VERSION=$(npm view @nx/workspace version)
           CURRENT_BRANCH="update-nrwl-workspace-${LAST_VERSION}"
-          # Find and close all open PRs with titles starting with "Update @nx/workspace to", except the current one
-          gh pr list --state open --json number,title,headRefName --jq '.[] | select(.title | startswith("Update @nx/workspace to")) | select(.headRefName != "'"${CURRENT_BRANCH}"'") | .number' | while read -r pr_number; do
+          # Find and close all open @nx/workspace update PRs, matched by branch
+          # name (stable) rather than title (now a Conventional Commit), except
+          # the current one
+          gh pr list --state open --json number,headRefName --jq '.[] | select(.headRefName | startswith("update-nrwl-workspace-")) | select(.headRefName != "'"${CURRENT_BRANCH}"'") | .number' | while read -r pr_number; do
             echo "Closing PR #${pr_number}"
             gh pr close ${pr_number} --comment "Closing in favor of newer @nx/workspace update PR"
           done


### PR DESCRIPTION
## Summary

The `nx-migrate` workflow opens its auto-update PR with the title
`Update @nx/workspace to update-nrwl-workspace-<version>`, which is not a
Conventional Commit header (no type, no subject). Because this repo squash-merges,
that title can become the commit message on `main`.

It only bites when the PR carries more than one commit. GitHub's squash default uses
the **PR title** for multi-commit PRs, but the first commit's message for
single-commit ones:

- Nothing to migrate, so a single `build: 📦 …` commit. GitHub squashes using that
  conventional message and the update lands clean automatically (e.g. #1071, #1068).
- Migrations present, so the workflow adds a second `remove migrations.json` commit.
  GitHub squashes using the non-conventional **PR title**, and whoever merges has to
  fix the message by hand (#1063 was fixed, #1080 slipped through and landed
  `d536572e` on `main`).

Once a non-conventional commit is on `main`, the `semver` package's `lint` target
(which depends on `lint-commits` running `commitlint --from=last-release`) fails for
every branch cut from `main` until the next release moves the `last-release` tag past
it. That breakage is tracked in #1090.

## Change

- Give both the bot commit and the PR title the conventional header
  `build: 📦 update @nx/workspace to <version>`, defined once as a job-level env var
  so the two call sites cannot drift. The squash-merged commit is now valid no matter
  how many commits the PR carries, removing the reliance on a manual fix for
  migration updates.
- The "Close old @nx/workspace PRs" step matched PRs by the old title prefix, which
  the new conventional title no longer starts with. Match by branch name
  (`update-nrwl-workspace-*`) instead, which is stable and independent of the title
  format, so stale update PRs keep getting auto-closed.

## Known limitation

`gh pr create -t` sets the title only when a brand-new PR is opened. If a PR for the
current latest version is already open, `gh pr view` short-circuits and the title is
not re-applied, so this fix reaches new PRs only, not ones already in flight (such as
#1087). Those still need a manual title fix, or a follow-up could add
`gh pr edit --title` to bring existing PRs in line on each run.

## Notes

- This is the prevention / root-cause fix. It does not reword the commit already on
  `main` (`d536572e`); that one-off cleanup is tracked in #1090.
- The `lint-commits` check on this PR stays red until `d536572e` is reworded on
  `main`, because `pull_request` CI lints the merge into `main`, which still contains
  that commit. The branch is based one commit before `d536572e` (on the
  `last-release` commit), so once #1090 is resolved a single "Update branch" rebase
  turns the check green without baking the broken commit into this branch.
