### PR TITLE
feat(semver)!: support Nx 23 and drop support for Nx < 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,20 +494,21 @@ For more details on using Nx Release, refer to the [official Nx documentation](h
 
 ## Compatibility overview with Nx
 
-| Version | Required Package          |
-| ------- | ------------------------- |
-| v5.8.0  | `@nx/devkit ^22.0.0`      |
-| v5.7.0  | `@nx/devkit ^21.0.0`      |
-| v5.5.0  | `@nx/devkit ^20.0.0`      |
-| v5.3.0  | `@nx/devkit ^19.0.0`      |
-| v5.0.0  | `@nx/devkit ^18.0.0`      |
-| v4.0.0  | `@nx/devkit ^17.0.0`      |
-| v3.0.0  | `@nx/devkit ^16.0.0`      |
-| v2.28.0 | `@nrwl/devkit ^15.0.0`    |
-| v2.23.0 | `@nrwl/devkit ^14.0.0`    |
-| v2.12.0 | `@nrwl/workspace ^13.0.0` |
-| v2.4.0  | `@nrwl/workspace ^12.0.0` |
-| v1.0.0  | `@nrwl/workspace ^11.0.0` |
+| Version | Required Package                                            |
+| ------- | ----------------------------------------------------------- |
+| v7.0.0  | `@nx/devkit ^20.0.0 \|\| ^21.0.0 \|\| ^22.0.0 \|\| ^23.0.0` |
+| v5.8.0  | `@nx/devkit ^22.0.0`                                        |
+| v5.7.0  | `@nx/devkit ^21.0.0`                                        |
+| v5.5.0  | `@nx/devkit ^20.0.0`                                        |
+| v5.3.0  | `@nx/devkit ^19.0.0`                                        |
+| v5.0.0  | `@nx/devkit ^18.0.0`                                        |
+| v4.0.0  | `@nx/devkit ^17.0.0`                                        |
+| v3.0.0  | `@nx/devkit ^16.0.0`                                        |
+| v2.28.0 | `@nrwl/devkit ^15.0.0`                                      |
+| v2.23.0 | `@nrwl/devkit ^14.0.0`                                      |
+| v2.12.0 | `@nrwl/workspace ^13.0.0`                                   |
+| v2.4.0  | `@nrwl/workspace ^12.0.0`                                   |
+| v1.0.0  | `@nrwl/workspace ^11.0.0`                                   |
 
 ## Changelog
 

--- a/packages/semver/package.json
+++ b/packages/semver/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/jscutlery/semver"
   },
   "peerDependencies": {
-    "@nx/devkit": "^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0 || ^22.0.0"
+    "@nx/devkit": "^20.0.0 || ^21.0.0 || ^22.0.0 || ^23.0.0"
   },
   "dependencies": {
     "chalk": "4.1.2",

--- a/packages/semver/src/executors/version/utils/get-project-dependencies.spec.ts
+++ b/packages/semver/src/executors/version/utils/get-project-dependencies.spec.ts
@@ -13,7 +13,6 @@ jest.mock('@nx/devkit', () => ({
   ...jest.requireActual('@nx/devkit'),
   createProjectGraphAsync: mockCreateProjectGraphAsync,
 }));
-jest.mock('@nx/workspace/src/core/project-graph', () => ({}));
 
 const projectGraph: ProjectGraph = {
   nodes: {},

--- a/packages/semver/src/generators/migrate-nx-release/index.spec.ts
+++ b/packages/semver/src/generators/migrate-nx-release/index.spec.ts
@@ -125,10 +125,64 @@ describe('Nx Release Migration', () => {
       release = readNxJson(tree)!.release;
     }
 
-    it('should configure release.releaseTagPattern', async () => {
+    it('should configure the release tag pattern', async () => {
       await setupSemver();
 
-      expect(release!.releaseTagPattern).toBe(`{projectName}-{version}`);
+      // The generator emits the nested `releaseTag.pattern` on Nx >= 22 and the
+      // flat `releaseTagPattern` on Nx < 22, so assert whichever the installed
+      // Nx produced to stay green across the whole supported range.
+      const { releaseTag, releaseTagPattern } = release as unknown as {
+        releaseTag?: { pattern?: string };
+        releaseTagPattern?: string;
+      };
+      expect(releaseTag?.pattern ?? releaseTagPattern).toBe(
+        `{projectName}-{version}`,
+      );
+    });
+
+    afterEach(() => jest.restoreAllMocks());
+
+    function mockInstalledNxMajor(version: string) {
+      jest.spyOn(devkit, 'readJsonFile').mockReturnValue({ version } as never);
+    }
+
+    it('emits the flat releaseTagPattern on Nx < 22', async () => {
+      mockInstalledNxMajor('21.0.0');
+
+      await setupSemver();
+
+      const config = release as unknown as {
+        releaseTag?: unknown;
+        releaseTagPattern?: string;
+      };
+      expect(config.releaseTagPattern).toBe(`{projectName}-{version}`);
+      expect(config.releaseTag).toBeUndefined();
+    });
+
+    it('emits the nested releaseTag.pattern without the 0.x adjustment on Nx 22', async () => {
+      mockInstalledNxMajor('22.0.0');
+
+      await setupSemver();
+
+      const config = release as unknown as {
+        releaseTag?: { pattern?: string };
+        version?: { adjustSemverBumpsForZeroMajorVersion?: boolean };
+      };
+      expect(config.releaseTag?.pattern).toBe(`{projectName}-{version}`);
+      expect(
+        config.version?.adjustSemverBumpsForZeroMajorVersion,
+      ).toBeUndefined();
+    });
+
+    it('opts out of adjustSemverBumpsForZeroMajorVersion on Nx >= 23', async () => {
+      mockInstalledNxMajor('23.0.0');
+
+      await setupSemver();
+
+      const version = release!.version as unknown as {
+        adjustSemverBumpsForZeroMajorVersion?: boolean;
+      };
+      expect(version.adjustSemverBumpsForZeroMajorVersion).toBe(false);
     });
 
     it('should configure projects', async () => {

--- a/packages/semver/src/generators/migrate-nx-release/index.ts
+++ b/packages/semver/src/generators/migrate-nx-release/index.ts
@@ -7,12 +7,14 @@ import {
   readNxJson,
   formatFiles,
   writeJson,
+  readJsonFile,
   TargetConfiguration,
   installPackagesTask,
   updateJson,
   NxJsonConfiguration,
   detectPackageManager,
 } from '@nx/devkit';
+import { major } from 'semver';
 import { VersionBuilderSchema } from '../../executors/version/schema';
 import { defaultHeader } from '../../executors/version/utils/changelog';
 
@@ -155,6 +157,13 @@ function removeSemverTargets(
   updateProjectConfiguration(tree, projectName, projectConfig);
 }
 
+function getInstalledNxMajorVersion(): number {
+  const { version } = readJsonFile<{ version: string }>(
+    require.resolve('nx/package.json'),
+  );
+  return major(version);
+}
+
 function configureNxRelease(
   tree: Tree,
   semverProjects: [string, ProjectConfiguration][],
@@ -183,14 +192,25 @@ function configureNxRelease(
 
   const pm = detectPackageManager(tree.root);
   const runCmd = pm === 'yarn' ? 'yarn' : pm === 'npm' ? 'npx' : 'pnpm exec';
+  const nxMajor = getInstalledNxMajorVersion();
 
   nxJson.release = {
-    releaseTagPattern: `${tagPrefix}{version}`,
+    // Nx 23 removed the flat `releaseTagPattern` in favour of the nested
+    // `releaseTag.pattern` that was introduced in Nx 22. Nx < 22 only
+    // understands the flat form, so emit the shape the installed Nx supports.
+    ...(nxMajor >= 22
+      ? { releaseTag: { pattern: `${tagPrefix}{version}` } }
+      : { releaseTagPattern: `${tagPrefix}{version}` }),
     projects: semverProjects.map(([projectName]) => projectName),
     projectsRelationship: 'independent',
     version: {
       preVersionCommand: `${runCmd} nx run-many -t build`,
       conventionalCommits: true,
+      // Nx 23 defaults `adjustSemverBumpsForZeroMajorVersion` to `true`, which
+      // bumps 0.x features as patches. Nx < 23 has no such option and already
+      // bumps them as minors, so only opt out on Nx >= 23 to keep the
+      // `@jscutlery/semver` versioning behavior consistent across the range.
+      ...(nxMajor >= 23 ? { adjustSemverBumpsForZeroMajorVersion: false } : {}),
     },
     git: {
       commit: options.skipCommit != true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,7 +111,7 @@ importers:
   packages/semver:
     dependencies:
       '@nx/devkit':
-        specifier: ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0 || ^22.0.0
+        specifier: ^20.0.0 || ^21.0.0 || ^22.0.0 || ^23.0.0
         version: 22.6.3(nx@22.7.0(@swc-node/register@1.11.1(@swc/core@1.15.8)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8))
       chalk:
         specifier: 4.1.2


### PR DESCRIPTION
Implements **Option A** from #1093. Opening as a draft for discussion, since the direction (Option A vs. Option B) is still open there.

Adds Nx 23 support. Unlike the earlier Nx 21 and Nx 22 updates, this is not a peer-range-only bump: Nx 23 removed the flat `releaseTagPattern` property from `NxReleaseConfiguration` (moved to the nested `releaseTag.pattern` in Nx 22) and now rejects it at runtime, so the `nx.json` written by the `migrate-nx-release` generator broke `nx release`. The generator now emits the nested shape.

> [!WARNING]
> **This drops backward compatibility.** The nested `releaseTag.pattern` shape only exists in Nx >= 22, so the peer range is narrowed to `^22.0.0 || ^23.0.0` and support for Nx 18-21 is dropped. This is a breaking change (major bump).

If you'd prefer to keep backward compatibility instead (Option B in #1093: a version-aware generator that emits the flat shape for Nx < 22 and the nested shape for Nx >= 22), I'm happy to implement that and close this in favor of it.

## Changes

- `migrate-nx-release` generator emits the nested `releaseTag: { pattern }` shape.
- Peer range narrowed to `@nx/devkit ^22.0.0 || ^23.0.0`.
- Removed an obsolete test-only mock of `@nx/workspace/src/core/project-graph`, which is unreachable under Nx 23's tightened `exports` map (the executor source only uses public `@nx/devkit` entrypoints).
- Updated the README compatibility table.

## Verification

Migrated the dev workspace to Nx 23 and ran the build and full test suite; both green. Re-verified green on Nx 22 as well, so the change works across the whole `^22.0.0 || ^23.0.0` range.

## Related

- #1093 - the Option A vs. Option B decision this PR belongs to.
- #1092 - CI matrix to actually test the supported Nx range; ideally landed first, independent of the A/B decision.
