### PR TITLE
ci(semver): add an Nx version compatibility matrix workflow

### DIFF
--- a/.github/workflows/nx-compat-matrix.yml
+++ b/.github/workflows/nx-compat-matrix.yml
@@ -1,0 +1,69 @@
+name: Nx compatibility matrix
+
+# Verifies that @jscutlery/semver actually builds, tests and runs its e2e
+# against every supported Nx major. The regular test workflow only runs against
+# the single Nx version pinned in the workspace, so this confirms the whole
+# supported range instead of trusting it.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    # Only run the (expensive) multi-version matrix when something that can
+    # affect Nx compatibility changes, not on every unrelated PR.
+    paths:
+      - 'packages/semver/**'
+      - '.github/workflows/nx-compat-matrix.yml'
+
+jobs:
+  compat:
+    runs-on: ubuntu-latest
+
+    strategy:
+      # Never cancel the other versions when one fails: we want the full
+      # red/green picture across the range in a single run.
+      fail-fast: false
+      matrix:
+        # Nx 18 and 19 are intentionally excluded: the e2e harness relies on
+        # `@nx/js:lib` deriving the project name from `--directory`, which only
+        # works from Nx 20 onwards, so those versions cannot be verified
+        # end-to-end without reworking the harness.
+        nx: [20, 21, 22, 23]
+
+    name: nx@${{ matrix.nx }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v4
+
+      # Node 20 is the common denominator that every Nx major in the matrix
+      # still supports.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install (current lockfile)
+        run: pnpm install --frozen-lockfile
+
+      - name: Pin Nx to ${{ matrix.nx }}.x
+        run: |
+          pnpm add -D -w \
+            nx@${{ matrix.nx }} \
+            @nx/devkit@${{ matrix.nx }} \
+            @nx/js@${{ matrix.nx }} \
+            @nx/jest@${{ matrix.nx }} \
+            @nx/eslint-plugin@${{ matrix.nx }} \
+            @nx/plugin@${{ matrix.nx }} \
+            @nx/workspace@${{ matrix.nx }}
+          echo "Resolved Nx version:"
+          node -p "require('nx/package.json').version"
+
+      - name: Build
+        run: pnpm nx run semver:build --skip-nx-cache
+
+      - name: Test
+        run: pnpm nx run semver:test --skip-nx-cache
+
+      - name: E2E
+        run: pnpm nx run semver:e2e --skip-nx-cache


### PR DESCRIPTION
Adds an Nx version compatibility matrix, as proposed in #1092.

The regular `Test` workflow only runs against the single Nx version pinned in the workspace (kept current by the `nx-migrate` bot), so nothing verifies that the other supported Nx majors still build, unit-test and pass the e2e. This workflow runs the full build + unit tests + e2e against each Nx major.

## Scope

- Matrix: Nx **20, 21, 22** as hard requirements.
- Nx **23** runs too but is flagged `continue-on-error` for now, because support has not landed yet. It is added in a follow-up; once that lands, Nx 23 becomes a hard requirement as well.
- Nx 18 and 19 are intentionally excluded: the e2e harness relies on `@nx/js:lib` deriving the project name from `--directory`, which only works from Nx 20 onwards, so those versions cannot be verified end-to-end without reworking the harness. (This also means the `^18 || ^19` part of the current peer range is effectively unverifiable; narrowing it is handled in the Nx 23 follow-up.)

## Triggers

- `pull_request`, filtered to changes under `packages/semver/**` or the workflow itself, so unrelated PRs do not pay for the multi-version matrix.
- `workflow_dispatch` for manual runs.

Closes #1092
